### PR TITLE
Making base64 encoding/decoding optional

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ organization := "com.github.dnvriend"
 
 name := "akka-persistence-jdbc"
 
-version := "1.0.8"
+version := "1.0.9-SNAPSHOT"
 
 scalaVersion := "2.11.2"
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -14,6 +14,11 @@ jdbc-snapshot-store {
 //  class = "akka.persistence.jdbc.journal.OracleSyncSnapshotStore"
 }
 
+jdbc-event-encoding {
+  base64 = true
+  base64 = ${?JDBC_EVENT_ENCODING_BASE64}
+}
+
 jdbc-connection {
   username           = "docker"
   password           = "docker"

--- a/src/main/scala/akka/persistence/jdbc/common/ActorConfig.scala
+++ b/src/main/scala/akka/persistence/jdbc/common/ActorConfig.scala
@@ -27,6 +27,8 @@ class PluginConfig(system: ActorSystem) {
   def journalTableName = config.getString("journalTableName")
   def snapshotSchemaName: String = config.getString("snapshotSchemaName").toOption.map(_ + ".").getOrElse("")
   def snapshotTableName = config.getString("snapshotTableName")
+
+  def base64 = system.settings.config.getBoolean("jdbc-event-encoding.base64")
 }
 
 trait ActorConfig { this: Actor =>

--- a/src/main/scala/akka/persistence/jdbc/journal/Statements.scala
+++ b/src/main/scala/akka/persistence/jdbc/journal/Statements.scala
@@ -2,7 +2,7 @@ package akka.persistence.jdbc.journal
 
 import akka.persistence.PersistentRepr
 import akka.persistence.jdbc.common.PluginConfig
-import akka.persistence.jdbc.util.{Base64, EncodeDecode}
+import akka.persistence.jdbc.util.{ByteString, Base64, EncodeDecode}
 import scalikejdbc._
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -28,23 +28,24 @@ trait GenericStatements extends JdbcStatements with EncodeDecode {
   implicit val session: DBSession
   val cfg: PluginConfig
 
+  implicit val base64 = cfg.base64
   val schema = cfg.journalSchemaName
   val table = cfg.journalTableName
 
   def selectMessage(persistenceId: String, sequenceNr: Long): Option[PersistentRepr] =
     SQL(s"SELECT message FROM $schema$table WHERE persistence_id = ? AND sequence_number = ?").bind(persistenceId, sequenceNr)
-      .map(rs => Journal.fromBytes(Base64.decodeBinary(rs.string(1))))
+      .map(rs => Journal.fromBytes(decodeBinary(rs.string(1))))
       .single()
       .apply()
 
   def insertMessage(persistenceId: String, sequenceNr: Long, marker: String = "A", message: PersistentRepr) {
-    val msgToWrite = Base64.encodeString(Journal.toBytes(message))
+    val msgToWrite = encodeString(Journal.toBytes(message))
     SQL(s"INSERT INTO $schema$table (persistence_id, sequence_number, marker, message, created) VALUES (?,?,?,?, current_timestamp)")
       .bind(persistenceId, sequenceNr, marker, msgToWrite).update().apply
   }
 
   def updateMessage(persistenceId: String, sequenceNr: Long, marker: String, message: PersistentRepr) {
-    val msgToWrite = Base64.encodeString(Journal.toBytes(message))
+    val msgToWrite = encodeString(Journal.toBytes(message))
     SQL(s"UPDATE $schema$table SET message = ?, marker = ? WHERE persistence_id = ? and sequence_number = ?")
       .bind(msgToWrite, marker, persistenceId, sequenceNr).update().apply
   }
@@ -72,7 +73,7 @@ trait GenericStatements extends JdbcStatements with EncodeDecode {
   def selectMessagesFor(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long): List[PersistentRepr] = {
     SQL(s"SELECT message FROM $schema$table WHERE persistence_id = ? and (sequence_number >= ? and sequence_number <= ?) ORDER BY sequence_number LIMIT ?")
       .bind(persistenceId, fromSequenceNr, toSequenceNr, max)
-      .map(rs => Journal.fromBytes(Base64.decodeBinary(rs.string(1))))
+      .map(rs => Journal.fromBytes(decodeBinary(rs.string(1))))
       .list()
       .apply
   }
@@ -87,7 +88,7 @@ trait H2Statements extends GenericStatements {
     val maxRecords = if (max == java.lang.Long.MAX_VALUE) java.lang.Integer.MAX_VALUE.toLong else max
     SQL(s"SELECT message FROM $schema$table WHERE persistence_id = ? and (sequence_number >= ? and sequence_number <= ?) ORDER BY sequence_number limit ?")
       .bind(persistenceId, fromSequenceNr, toSequenceNr, maxRecords)
-      .map(rs => Journal.fromBytes(Base64.decodeBinary(rs.string(1))))
+      .map(rs => Journal.fromBytes(decodeBinary(rs.string(1))))
       .list()
       .apply
   }
@@ -97,7 +98,7 @@ trait OracleStatements extends GenericStatements {
   override def selectMessagesFor(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long): List[PersistentRepr] = {
     SQL(s"SELECT message FROM $schema$table WHERE persistence_id = ? AND (sequence_number >= ? AND sequence_number <= ?) AND ROWNUM <= ? ORDER BY sequence_number")
       .bind(persistenceId, fromSequenceNr, toSequenceNr, max)
-      .map(rs => Journal.fromBytes(Base64.decodeBinary(rs.string(1))))
+      .map(rs => Journal.fromBytes(decodeBinary(rs.string(1))))
       .list()
       .apply
   }
@@ -107,7 +108,7 @@ trait MSSqlServerStatements extends GenericStatements {
   override def selectMessagesFor(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long): List[PersistentRepr] = {
     SQL(s"SELECT TOP ? message FROM $schema$table WHERE persistence_id = ? AND (sequence_number >= ${} AND sequence_number <= ?) ORDER BY sequence_number")
       .bind(max, persistenceId, fromSequenceNr, toSequenceNr)
-      .map(rs => Journal.fromBytes(Base64.decodeBinary(rs.string(1))))
+      .map(rs => Journal.fromBytes(decodeBinary(rs.string(1))))
       .list()
       .apply
   }
@@ -117,7 +118,7 @@ trait DB2Statements extends GenericStatements {
   override def selectMessagesFor(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long): List[PersistentRepr] = {
     SQL(s"SELECT message FROM $schema$table WHERE persistence_id = ? AND (sequence_number >= ? AND sequence_number <= ?) ORDER BY sequence_number FETCH FIRST ? ROWS ONLY")
       .bind(persistenceId, fromSequenceNr, toSequenceNr, max)
-      .map(rs => Journal.fromBytes(Base64.decodeBinary(rs.string(1))))
+      .map(rs => Journal.fromBytes(decodeBinary(rs.string(1))))
       .list()
       .apply
   }

--- a/src/main/scala/akka/persistence/jdbc/snapshot/Statements.scala
+++ b/src/main/scala/akka/persistence/jdbc/snapshot/Statements.scala
@@ -22,6 +22,7 @@ trait GenericStatements extends JdbcStatements with EncodeDecode {
   implicit val session: DBSession
   val cfg: PluginConfig
 
+  implicit val base64 = cfg.base64
   val schema = cfg.snapshotSchemaName
   val table = cfg.snapshotTableName
 
@@ -30,7 +31,7 @@ trait GenericStatements extends JdbcStatements with EncodeDecode {
       .bind(metadata.persistenceId, metadata.sequenceNr).update().apply
 
   def writeSnapshot(metadata: SnapshotMetadata, snapshot: Snapshot): Unit = {
-    val snapshotData = Base64.encodeString(Snapshot.toBytes(snapshot))
+    val snapshotData = encodeString(Snapshot.toBytes(snapshot))
     import metadata._
     Try {
       SQL(s"INSERT INTO $schema$table (persistence_id, sequence_nr, created, snapshot) VALUES (?, ?, ?, ?)")
@@ -46,7 +47,7 @@ trait GenericStatements extends JdbcStatements with EncodeDecode {
       .bind(persistenceId, criteria.maxSequenceNr)
       .map { rs =>
       SelectedSnapshot(SnapshotMetadata(rs.string("persistence_id"), rs.long("sequence_nr"), rs.long("created")),
-        Snapshot.fromBytes(Base64.decodeBinary(rs.string("snapshot"))).data)
+        Snapshot.fromBytes(decodeBinary(rs.string("snapshot"))).data)
     }
       .list()
       .apply()
@@ -61,7 +62,7 @@ trait H2Statements extends GenericStatements
 
 trait OracleStatements extends GenericStatements {
   override def writeSnapshot(metadata: SnapshotMetadata, snapshot: Snapshot): Unit = {
-    val snapshotData = Base64.encodeString(Snapshot.toBytes(snapshot))
+    val snapshotData = encodeString(Snapshot.toBytes(snapshot))
     import metadata._
 
     SQL( s"""MERGE INTO $schema$table snapshot

--- a/src/main/scala/akka/persistence/jdbc/util/Base64.scala
+++ b/src/main/scala/akka/persistence/jdbc/util/Base64.scala
@@ -1,5 +1,7 @@
 package akka.persistence.jdbc.util
 
+import java.nio.charset.Charset
+
 import akka.persistence.serialization.Snapshot
 import akka.persistence.PersistentRepr
 import akka.serialization.Serialization
@@ -40,6 +42,13 @@ object Base64 {
   def decodeBinary(in: Array[Byte]): Array[Byte] = (new B64).decode(in)
 }
 
+object ByteString {
+  val UTF8 = Charset.forName("UTF-8")
+
+  def encodeBinary(in: Array[Byte]): String = new String(in, UTF8)
+  def decodeBinary(in: String): Array[Byte] = in.getBytes(UTF8)
+}
+
 trait EncodeDecode {
   def serialization: Serialization
 
@@ -53,5 +62,15 @@ trait EncodeDecode {
     def toBytes(msg: Snapshot): Array[Byte] = serialization.serialize(msg).get
 
     def fromBytes(bytes: Array[Byte]): Snapshot = serialization.deserialize(bytes, classOf[Snapshot]).get
+  }
+
+  def encodeString(in: Array[Byte])(implicit base64: Boolean = true): String = base64 match {
+    case true => Base64.encodeString(in)
+    case false => ByteString.encodeBinary(in)
+  }
+
+  def decodeBinary(in: String)(implicit base64: Boolean = true): Array[Byte] = base64 match {
+    case true => Base64.decodeBinary(in)
+    case false => ByteString.decodeBinary(in)
   }
 }


### PR DESCRIPTION
I am storing my messages as Json in to the database and I didn't want them to be base64 so I made it optional. 