### PR TITLE
Adds ´validationQuery´ configuration parameter

### DIFF
--- a/src/main/scala/akka/persistence/jdbc/common/ActorConfig.scala
+++ b/src/main/scala/akka/persistence/jdbc/common/ActorConfig.scala
@@ -27,6 +27,7 @@ class PluginConfig(system: ActorSystem) {
   def journalTableName = config.getString("journalTableName")
   def snapshotSchemaName: String = config.getString("snapshotSchemaName").toOption.map(_ + ".").getOrElse("")
   def snapshotTableName = config.getString("snapshotTableName")
+  def validationQuery = if(config.hasPath("validationQuery")) config.getString("validationQuery") else null
 }
 
 trait ActorConfig { this: Actor =>

--- a/src/main/scala/akka/persistence/jdbc/extension/ScalikeExtension.scala
+++ b/src/main/scala/akka/persistence/jdbc/extension/ScalikeExtension.scala
@@ -2,7 +2,7 @@ package akka.persistence.jdbc.extension
 
 import akka.actor.{ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider}
 import akka.persistence.jdbc.common.PluginConfig
-import scalikejdbc.{AutoSession, ConnectionPool}
+import scalikejdbc.{AutoSession, ConnectionPool, ConnectionPoolSettings}
 
 object ScalikeExtension extends ExtensionId[ScalikeExtensionImpl] with ExtensionIdProvider {
   override def createExtension(system: ExtendedActorSystem): ScalikeExtensionImpl = new ScalikeExtensionImpl(system)
@@ -16,5 +16,6 @@ class ScalikeExtensionImpl(system: ExtendedActorSystem) extends Extension {
   val poolName = "akka-persistence-jdbc"
 
   Class.forName(cfg.driverClassName)
-  ConnectionPool.singleton(cfg.url, cfg.username, cfg.password)
+  val connectionPoolSettings = new ConnectionPoolSettings(validationQuery = cfg.validationQuery)
+  ConnectionPool.singleton(cfg.url, cfg.username, cfg.password, connectionPoolSettings)
 }


### PR DESCRIPTION
This adds a new `validationQuery` configuration parameter. If the `jdbc-connection` configuration doesn't have a `validationQuery` field then it is set to `null` (`ConnectionPoolSettings` would still work as expected [according to its default value](https://github.com/scalikejdbc/scalikejdbc/blob/develop/scalikejdbc-core/src/main/scala/scalikejdbc/ConnectionPoolSettings.scala#L25)).

This may solve issue #9 according to [a suggestion  by Victor Klang](https://groups.google.com/d/msg/akka-user/xRappYKjoho/3sYnCk0X9K8J). We are having this issue when using Oracle, so (for us) the solution maybe is to have a `validationQuery`config field set to `select 1 from dual`. I'm not sure if this is the solution, I'm only following Victor's suggestion. Also, I'm not sure if this same problem occurs with other DBs. 