### PR TITLE
use apache commons codec Base64 vs the java8-only java.util.Base64

### DIFF
--- a/src/main/scala/akka/persistence/jdbc/serialization/snapshot/Base64SnapshotConverter.scala
+++ b/src/main/scala/akka/persistence/jdbc/serialization/snapshot/Base64SnapshotConverter.scala
@@ -1,15 +1,15 @@
 package akka.persistence.jdbc.serialization.snapshot
 
-import java.util.Base64
 
 import akka.persistence.jdbc.serialization.SnapshotTypeConverter
 import akka.persistence.serialization.Snapshot
 import akka.serialization.Serialization
+import org.apache.commons.codec.binary.Base64
 
 class Base64SnapshotConverter extends SnapshotTypeConverter {
    override def marshal(value: Snapshot)(implicit serialization: Serialization): String =
-     serialization.serialize(value).map(Base64.getEncoder.encodeToString).get
+     serialization.serialize(value).map(new Base64().encodeToString).get
 
    override def unmarshal(value: String)(implicit serialization: Serialization): Snapshot =
-     serialization.deserialize(Base64.getDecoder.decode(value), classOf[Snapshot]).get
+     serialization.deserialize(new Base64().decode(value), classOf[Snapshot]).get
  }


### PR DESCRIPTION
This change fixes the codebase so it'll still build against java7