### PR TITLE
use apache commons codec Base64 vs the java8-only java.util.Base64

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,7 @@ libraryDependencies ++= {
     "com.typesafe.akka"   %% "akka-actor"                    % akkaVersion,
     "com.typesafe.akka"   %% "akka-persistence-experimental" % akkaVersion,
     "org.scalikejdbc"     %% "scalikejdbc"                   % "2.2.5",
+    "commons-codec"        % "commons-codec"                 % "1.10",
     "ch.qos.logback"       % "logback-classic"               % "1.1.2"           % Test,
     "com.typesafe.akka"   %% "akka-slf4j"                    % akkaVersion       % Test,
     "ch.qos.logback"       % "logback-classic"               % "1.1.2"           % Test,

--- a/src/main/scala/akka/persistence/jdbc/serialization/journal/Base64JournalConverter.scala
+++ b/src/main/scala/akka/persistence/jdbc/serialization/journal/Base64JournalConverter.scala
@@ -1,15 +1,15 @@
 package akka.persistence.jdbc.serialization.journal
 
-import java.util.Base64
 
 import akka.persistence.PersistentRepr
 import akka.persistence.jdbc.serialization.JournalTypeConverter
 import akka.serialization.Serialization
+import org.apache.commons.codec.binary.Base64
 
 class Base64JournalConverter extends JournalTypeConverter {
   override def marshal(value: PersistentRepr)(implicit serialization: Serialization): String =
-    serialization.serialize(value).map(Base64.getEncoder.encodeToString).get
+    serialization.serialize(value).map(new Base64().encodeToString).get
 
   override def unmarshal(value: String)(implicit serialization: Serialization): PersistentRepr =
-    serialization.deserialize(Base64.getDecoder.decode(value), classOf[PersistentRepr]).get
+    serialization.deserialize(new Base64().decode(value), classOf[PersistentRepr]).get
 }

--- a/src/main/scala/akka/persistence/jdbc/serialization/snapshot/Base64SnapshotConverter.scala
+++ b/src/main/scala/akka/persistence/jdbc/serialization/snapshot/Base64SnapshotConverter.scala
@@ -1,15 +1,15 @@
 package akka.persistence.jdbc.serialization.snapshot
 
-import java.util.Base64
 
 import akka.persistence.jdbc.serialization.SnapshotTypeConverter
 import akka.persistence.serialization.Snapshot
 import akka.serialization.Serialization
+import org.apache.commons.codec.binary.Base64
 
 class Base64SnapshotConverter extends SnapshotTypeConverter {
    override def marshal(value: Snapshot)(implicit serialization: Serialization): String =
-     serialization.serialize(value).map(Base64.getEncoder.encodeToString).get
+     serialization.serialize(value).map(new Base64().encodeToString).get
 
    override def unmarshal(value: String)(implicit serialization: Serialization): Snapshot =
-     serialization.deserialize(Base64.getDecoder.decode(value), classOf[Snapshot]).get
+     serialization.deserialize(new Base64().decode(value), classOf[Snapshot]).get
  }


### PR DESCRIPTION
java.util.Base64 was only created in Java 8.  By using apache commons, this library can still be built against Java 7.