### PR TITLE
use a ParameterBinder to pass snapshot into the merge statement and get rid of the stored procedure.

### DIFF
--- a/src/main/scala/akka/persistence/jdbc/snapshot/Statements.scala
+++ b/src/main/scala/akka/persistence/jdbc/snapshot/Statements.scala
@@ -107,11 +107,6 @@ trait H2Statements extends GenericStatements
 trait OracleStatements extends GenericStatements {
   override def writeSnapshot(metadata: SnapshotMetadata, snapshot: Snapshot): Unit = {
     import metadata._
-    /*    SQL("call sp_save_snapshot(?, ?, ?, ?)")
-      .bind(persistenceId, sequenceNr, marshal(snapshot), timestamp)
-      .execute()
-      .apply()*/
-
 
     DB autoCommit { session =>
 

--- a/src/test/scala/akka/persistence/jdbc/snapshot/JdbcSyncSnapshotStoreSpec.scala
+++ b/src/test/scala/akka/persistence/jdbc/snapshot/JdbcSyncSnapshotStoreSpec.scala
@@ -35,7 +35,11 @@ trait JdbcSyncSnapshotStoreSpec extends SnapshotStoreSpec with JdbcInit {
         if(seqNo % 100 == 0) log.info("{}", seqNo)
         val metadata = SnapshotMetadata(persistenceId = pid, sequenceNr = seqNo, timestamp = System.currentTimeMillis())
         snapshotStore.tell(SaveSnapshot(metadata, MacBeth.text), senderProbe.ref)
-        senderProbe.expectMsgPF(1.minute) { case SaveSnapshotSuccess(md) => md }
+        senderProbe.expectMsgPF(10.minute) {
+          case SaveSnapshotSuccess(md) => md
+          case notSucess:Object=>
+            log.error(notSucess.toString)
+        }
       }
       snapshotStore.tell(LoadSnapshot(pid, SnapshotSelectionCriteria.Latest, Long.MaxValue), senderProbe.ref)
       senderProbe.expectMsgPF() {
@@ -49,10 +53,10 @@ trait JdbcSyncSnapshotStoreSpec extends SnapshotStoreSpec with JdbcInit {
       (1 to 1000).toStream.foreach { seqNo =>
         val metadata = SnapshotMetadata(persistenceId = pid, sequenceNr = seqNo, timestamp = System.currentTimeMillis())
         snapshotStore.tell(SaveSnapshot(metadata, MacBeth.text), senderProbe.ref)
-        senderProbe.expectMsgPF() { case SaveSnapshotSuccess(md) => md }
+        senderProbe.expectMsgPF(1.minute) { case SaveSnapshotSuccess(md) => md }
       }
       snapshotStore.tell(LoadSnapshot(pid, SnapshotSelectionCriteria(999, Long.MaxValue), Long.MaxValue), senderProbe.ref)
-      senderProbe.expectMsgPF(1.minute) {
+      senderProbe.expectMsgPF(3.minute) {
         case lssr @ LoadSnapshotResult(Some(SelectedSnapshot(SnapshotMetadata(`pid`, 999, _), _)), _) => lssr
       }
     }

--- a/src/test/scala/akka/persistence/jdbc/snapshot/JdbcSyncSnapshotStoreSpec.scala
+++ b/src/test/scala/akka/persistence/jdbc/snapshot/JdbcSyncSnapshotStoreSpec.scala
@@ -43,7 +43,7 @@ trait JdbcSyncSnapshotStoreSpec extends SnapshotStoreSpec with JdbcInit {
       }
       snapshotStore.tell(LoadSnapshot(pid, SnapshotSelectionCriteria.Latest, Long.MaxValue), senderProbe.ref)
       senderProbe.expectMsgPF() {
-        case lssr @ LoadSnapshotResult(Some(SelectedSnapshot(SnapshotMetadata(`pid`, 1000, _), _)), _) => lssr
+        case lssr @ LoadSnapshotResult(Some(SelectedSnapshot(SnapshotMetadata(`pid`, 1000, _), MacBeth.text)), _) => lssr
       }
     }
 
@@ -57,7 +57,7 @@ trait JdbcSyncSnapshotStoreSpec extends SnapshotStoreSpec with JdbcInit {
       }
       snapshotStore.tell(LoadSnapshot(pid, SnapshotSelectionCriteria(999, Long.MaxValue), Long.MaxValue), senderProbe.ref)
       senderProbe.expectMsgPF(3.minute) {
-        case lssr @ LoadSnapshotResult(Some(SelectedSnapshot(SnapshotMetadata(`pid`, 999, _), _)), _) => lssr
+        case lssr @ LoadSnapshotResult(Some(SelectedSnapshot(SnapshotMetadata(`pid`, 999, _), MacBeth.text)), _) => lssr
       }
     }
   }


### PR DESCRIPTION
Some DBAs frown on stored procedures.  This change eliminates the need for the stored procedure.  

And locally some tests were failing for me because timeouts were too short.  I increased some of the timeouts in those tests.

I haven't updated the library's documents, so let me know if you want that as part of the change