### PR TITLE
don't fail on asyncWrite with empty messages

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ organization := "com.github.dnvriend"
 
 name := "akka-persistence-jdbc"
 
-version := "1.2.0"
+version := "1.2.1-SNAPSHOT"
 
 scalaVersion := "2.11.7"
 

--- a/src/main/scala/akka/persistence/jdbc/journal/JdbcSyncWriteJournal.scala
+++ b/src/main/scala/akka/persistence/jdbc/journal/JdbcSyncWriteJournal.scala
@@ -26,7 +26,10 @@ import scala.util.Try
 
 trait JdbcSyncWriteJournal extends AsyncWriteJournal with ActorConfig with JdbcStatements {
   override def asyncWriteMessages(messages: Seq[AtomicWrite]): Future[Seq[Try[Unit]]] =
-    Future.fromTry(Try(writeMessages(messages)))
+    if (messages.nonEmpty)
+      Future.fromTry(Try(writeMessages(messages)))
+    else
+      Future.successful(Seq.empty)
 
   override def asyncDeleteMessagesTo(persistenceId: String, toSequenceNr: Long): Future[Unit] =
     Future.fromTry(Try(deleteMessagesTo(persistenceId, toSequenceNr)))


### PR DESCRIPTION
While debugging weird bugs in my app I traced them to akka-persistence-jdbc:
I noticed that it generates like this:
```
INSERT INTO akka.journal (persistence_id, sequence_number, marker, message, created) VALUES 
```
Scalikejdbc logs error and after that application falls into the ask-timeout mess. I went through akka sources and if I understood right, it may execute asyncWriteMessages with empty messages list. So, here is the fix.

Please, release new version including it.