### PR TITLE
Make offset sequential on eventsByTag queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Configure `slick`:
   - `slick.driver.PostgresDriver`
   - `slick.driver.MySQLDriver`
   - `com.typesafe.slick.driver.oracle.OracleDriver`
-   
+
 ## DataSource lookup by JNDI name
 The plugin uses `slick` as the database access library. Slick [supports jndi](http://slick.typesafe.com/doc/3.1.1/database.html#using-a-jndi-name)
 for looking up [DataSource](http://docs.oracle.com/javase/7/docs/api/javax/sql/DataSource.html)s. 
@@ -535,6 +535,10 @@ event is provided in the EventEnvelope, which makes it possible to resume the st
 In addition to the offset the EventEnvelope also provides persistenceId and sequenceNr for each event. The sequenceNr is 
 the sequence number for the persistent actor with the persistenceId that persisted the event. The persistenceId + sequenceNr 
 is an unique identifier for the event.
+
+The returned event stream contains only events that correspond to the given tag, and is ordered by the creation time of the events,
+The same stream elements (in same order) are returned for multiple executions of the same query. Deleted events are not deleted
+from the tagged event stream.
 
 ## EventsByPersistenceIdAndTag and CurrentEventsByPersistenceIdAndTag
 `eventsByPersistenceIdAndTag` and `currentEventsByPersistenceIdAndTag` is used for retrieving specific events identified 

--- a/src/main/scala/akka/persistence/jdbc/dao/DefaultJournalQueries.scala
+++ b/src/main/scala/akka/persistence/jdbc/dao/DefaultJournalQueries.scala
@@ -72,7 +72,7 @@ class DefaultJournalQueries(val profile: JdbcProfile, override val journalTableC
       .take(max)
 
   def eventsByTag(tag: String, offset: Long): Query[Journal, JournalRow, Seq] =
-    JournalTable.filter(_.tags like s"%$tag%").sortBy(_.sequenceNumber.asc).filter(_.sequenceNumber >= offset)
+    JournalTable.filter(_.tags like s"%$tag%").sortBy(_.created.asc).drop(offset)
 
   def eventsByTagAndPersistenceId(persistenceId: String, tag: String, offset: Long): Query[Journal, JournalRow, Seq] =
     JournalTable.filter(_.persistenceId === persistenceId).filter(_.tags like s"%$tag%").sortBy(_.sequenceNumber.asc).filter(_.sequenceNumber >= offset)

--- a/src/main/scala/akka/persistence/jdbc/dao/inmemory/InMemoryJournalStorage.scala
+++ b/src/main/scala/akka/persistence/jdbc/dao/inmemory/InMemoryJournalStorage.scala
@@ -108,9 +108,8 @@ class InMemoryJournalStorage extends Actor with ActorLogging {
     val determine: List[SerializationResult] = (for {
       xs ← journal.values
       x ← xs
-      if x.sequenceNr >= offset
       if x.tags.exists(tags ⇒ SerializationFacade.decodeTags(tags, ",") contains tag)
-    } yield x).toList
+    } yield x).toList.sortBy(_.created).drop(offset.toInt)
     log.debug(s"[eventsByTag]: sending: $determine")
     ref ! determine
   }


### PR DESCRIPTION
Resolves #36 

The implementation assumes that the `offset` passed to the `eventsByTag` query will be <= to the actual event count since it'll be the starting point for the future events no matter how many were actually skipped.
This is enough for my usage and maybe as far as I can go with my very limited Akka Streams knowledge, but something better could be designed.

I restored the note about ordering in the README since it is still applicable.