### PR TITLE
Serialization issues should result in onPersistRejected() callback ra…

### DIFF
--- a/src/main/scala/akka/persistence/jdbc/dao/bytea/ByteArrayJournalDao.scala
+++ b/src/main/scala/akka/persistence/jdbc/dao/bytea/ByteArrayJournalDao.scala
@@ -43,7 +43,7 @@ class ByteArrayJournalDao(db: JdbcBackend#Database, val profile: JdbcProfile, sy
 
   private def writeMessages: Flow[Try[Iterable[SerializationResult]], Try[Iterable[SerializationResult]], NotUsed] = Flow[Try[Iterable[SerializationResult]]].mapAsync(1) {
     case element @ Success(xs) ⇒ writeList(xs).map(_ ⇒ element)
-    case element @ Failure(t)  ⇒ Future.failed(t)
+    case element @ Failure(t)  ⇒ Future.successful(element)
   }
 
   override def writeList(xs: Iterable[SerializationResult]): Future[Unit] = for {

--- a/src/main/scala/akka/persistence/jdbc/dao/inmemory/InMemoryJournalDao.scala
+++ b/src/main/scala/akka/persistence/jdbc/dao/inmemory/InMemoryJournalDao.scala
@@ -41,7 +41,7 @@ class InMemoryJournalDao(db: ActorRef)(implicit timeout: Timeout, ec: ExecutionC
 
   private def writeMessages: Flow[Try[Iterable[SerializationResult]], Try[Iterable[SerializationResult]], NotUsed] = Flow[Try[Iterable[SerializationResult]]].mapAsync(1) {
     case element @ Success(xs) ⇒ writeList(xs).map(_ ⇒ element)
-    case element @ Failure(t)  ⇒ Future.failed(t)
+    case element @ Failure(t)  ⇒ Future.successful(element)
   }
 
   override def allPersistenceIdsSource: Source[String, NotUsed] =

--- a/src/main/scala/akka/persistence/jdbc/dao/varchar/VarcharJournalDao.scala
+++ b/src/main/scala/akka/persistence/jdbc/dao/varchar/VarcharJournalDao.scala
@@ -94,7 +94,7 @@ class VarcharJournalDao(db: JdbcBackend#Database, val profile: JdbcProfile, syst
 
   val writeMessages: Flow[Try[Iterable[SerializationResult]], Try[Iterable[SerializationResult]], NotUsed] = Flow[Try[Iterable[SerializationResult]]].mapAsync(1) {
     case element @ Success(xs) ⇒ writeList(xs).map(_ ⇒ element)
-    case element @ Failure(t)  ⇒ Future.failed(t)
+    case element @ Failure(t)  ⇒ Future.successful(element)
   }
 
   override def writeList(xs: Iterable[SerializationResult]): Future[Unit] = for {

--- a/src/main/scala/akka/persistence/jdbc/serialization/SerializationProxy.scala
+++ b/src/main/scala/akka/persistence/jdbc/serialization/SerializationProxy.scala
@@ -104,7 +104,7 @@ class SerializationFacade(proxy: SerializationProxy, separator: String) {
     }
 
     val xs = atomicWrite.payload.map(serializeTaggedOrRepr)
-    if (xs.exists(_.isFailure)) xs.filter(_.isFailure).head.asInstanceOf[Try[Iterable[SerializationResult]]] // SI-8566
+    if (xs.exists(_.isFailure)) xs.filter(_.isFailure).head.map(Seq(_)) // SI-8566
     else Success(xs.foldLeft(List.empty[SerializationResult]) {
       case (xy, Success(serialized)) ⇒ xy :+ serialized
       case (xy, _)                   ⇒ xy

--- a/src/test/scala/akka/persistence/jdbc/serialization/StoreOnlySerializableMessagesTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/serialization/StoreOnlySerializableMessagesTest.scala
@@ -79,9 +79,9 @@ abstract class StoreOnlySerializableMessagesTest(config: String) extends TestSpe
       recover.expectMsg(RecoveryCompleted)
       recover.expectNoMsg(100.millis)
       actor ! new NotSerializable // the NotSerializable class cannot be serialized
-      // the actor should be called the onPersistFailure
-      failure.expectMsgPF() {
-        case PersistFailure(_, _, _) ⇒
+      // the actor should be called the OnPersistRejected
+      rejected.expectMsgPF() {
+        case PersistRejected(_, _, _) ⇒
       }
     }
 
@@ -99,11 +99,11 @@ abstract class StoreOnlySerializableMessagesTest(config: String) extends TestSpe
       recover.expectNoMsg(100.millis)
       actor ! "foo"
       actor ! new NotSerializable // the Test class cannot be serialized
-      // the actor should be called the onPersistFailure
-      failure.expectMsgPF() {
-        case PersistFailure(_, _, _) ⇒
+      // the actor should be called the onPersistRejected
+      rejected.expectMsgPF() {
+        case PersistRejected(_, _, _) ⇒
       }
-      failure.expectNoMsg(100.millis)
+      rejected.expectNoMsg(100.millis)
     }
 
     // recover cycle


### PR DESCRIPTION
…ther than onPersistFailure()

as per Akka persistence doc:

If persistence of an event fails, onPersistFailure will be invoked (logging the error by default), and the actor will unconditionally be stopped. If persistence of an event is rejected before it is stored, e.g. due to serialization error, onPersistRejected will be invoked (logging a warning by default) and the actor continues with the next message.