### PR TITLE
Honour the schemaName setting for the snapshot table

### DIFF
--- a/src/main/scala/akka/persistence/jdbc/dao/bytea/SnapshotTables.scala
+++ b/src/main/scala/akka/persistence/jdbc/dao/bytea/SnapshotTables.scala
@@ -30,7 +30,7 @@ trait SnapshotTables {
 
   def snapshotTableCfg: SnapshotTableConfiguration
 
-  class Snapshot(_tableTag: Tag) extends Table[SnapshotRow](_tableTag, _schemaName = None, _tableName = snapshotTableCfg.tableName) {
+  class Snapshot(_tableTag: Tag) extends Table[SnapshotRow](_tableTag, _schemaName = snapshotTableCfg.schemaName, _tableName = snapshotTableCfg.tableName) {
     def * = (persistenceId, sequenceNumber, created, snapshot) <> (SnapshotRow.tupled, SnapshotRow.unapply)
 
     val persistenceId: Rep[String] = column[String](snapshotTableCfg.columnNames.persistenceId, O.Length(255, varying = true), O.PrimaryKey)

--- a/src/main/scala/akka/persistence/jdbc/dao/varchar/SnapshotTables.scala
+++ b/src/main/scala/akka/persistence/jdbc/dao/varchar/SnapshotTables.scala
@@ -30,7 +30,7 @@ trait SnapshotTables {
 
   def snapshotTableCfg: SnapshotTableConfiguration
 
-  class Snapshot(_tableTag: Tag) extends Table[SnapshotRow](_tableTag, _schemaName = None, _tableName = snapshotTableCfg.tableName) {
+  class Snapshot(_tableTag: Tag) extends Table[SnapshotRow](_tableTag, _schemaName = snapshotTableCfg.schemaName, _tableName = snapshotTableCfg.tableName) {
     def * = (persistenceId, sequenceNumber, created, snapshot) <> (SnapshotRow.tupled, SnapshotRow.unapply)
 
     val persistenceId: Rep[String] = column[String](snapshotTableCfg.columnNames.persistenceId, O.Length(255, varying = true), O.PrimaryKey)

--- a/src/main/scala/akka/persistence/jdbc/extension/AkkaPersistenceConfig.scala
+++ b/src/main/scala/akka/persistence/jdbc/extension/AkkaPersistenceConfig.scala
@@ -106,7 +106,7 @@ object SnapshotTableConfiguration {
   def apply(cfg: Config): SnapshotTableConfiguration =
     cfg.withPath("akka-persistence-jdbc.tables.snapshot") { cfg ⇒
       SnapshotTableConfiguration(
-        cfg.as[String]("tableName", "journal"),
+        cfg.as[String]("tableName", "snapshot"),
         cfg.as[String]("schemaName").map(_.trim).filter(_.nonEmpty),
         cfg.withPath("columnNames") { cfg ⇒
           SnapshotTableColumnNames(


### PR DESCRIPTION
The `schemaName` setting in the configuration is currently being ignored for the snapshot table. This causes problems when using a schema other than `public` with Postgres (`ERROR: relation "snapshot" does not exist`).

