### PR TITLE
Fix for usage with h2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -75,9 +75,8 @@ scalacOptions ++= Seq(
 )
 
 // enable scala code formatting //
-import com.typesafe.sbt.SbtScalariform
-
 import scalariform.formatter.preferences._
+import com.typesafe.sbt.SbtScalariform
 
 // Scalariform settings
 SbtScalariform.autoImport.scalariformPreferences := SbtScalariform.autoImport.scalariformPreferences.value

--- a/build.sbt
+++ b/build.sbt
@@ -43,6 +43,7 @@ libraryDependencies ++= {
     "ch.qos.logback" % "logback-classic" % "1.1.7" % Test,
     "com.typesafe.akka" %% "akka-persistence-tck" % akkaVersion % Test,
     "org.postgresql" % "postgresql" % "9.4.1208" % Test,
+    "com.h2database" % "h2" % "1.4.191" % Test,
     "mysql" % "mysql-connector-java" % "5.1.39" % Test,
     "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion % Test,
     "com.typesafe.akka" %% "akka-testkit" % akkaVersion % Test,
@@ -74,8 +75,9 @@ scalacOptions ++= Seq(
 )
 
 // enable scala code formatting //
-import scalariform.formatter.preferences._
 import com.typesafe.sbt.SbtScalariform
+
+import scalariform.formatter.preferences._
 
 // Scalariform settings
 SbtScalariform.autoImport.scalariformPreferences := SbtScalariform.autoImport.scalariformPreferences.value

--- a/src/main/resources/schema/h2/h2-schema.sql
+++ b/src/main/resources/schema/h2/h2-schema.sql
@@ -1,0 +1,27 @@
+DROP TABLE IF EXISTS PUBLIC.journal;
+
+CREATE TABLE IF NOT EXISTS PUBLIC.journal (
+  persistence_id VARCHAR(255) NOT NULL,
+  sequence_number BIGINT NOT NULL,
+  created BIGINT NOT NULL,
+  tags VARCHAR(255) DEFAULT NULL,
+  message BYTEA NOT NULL,
+  PRIMARY KEY(persistence_id, sequence_number)
+);
+
+DROP TABLE IF EXISTS PUBLIC.deleted_to;
+
+CREATE TABLE IF NOT EXISTS PUBLIC.deleted_to (
+  persistence_id VARCHAR(255) NOT NULL,
+  deleted_to BIGINT NOT NULL
+);
+
+DROP TABLE IF EXISTS PUBLIC.snapshot;
+
+CREATE TABLE IF NOT EXISTS PUBLIC.snapshot (
+  persistence_id VARCHAR(255) NOT NULL,
+  sequence_number BIGINT NOT NULL,
+  created BIGINT NOT NULL,
+  snapshot BYTEA NOT NULL,
+  PRIMARY KEY(persistence_id, sequence_number)
+);

--- a/src/main/scala/akka/persistence/jdbc/dao/bytea/journal/ByteArrayJournalDao.scala
+++ b/src/main/scala/akka/persistence/jdbc/dao/bytea/journal/ByteArrayJournalDao.scala
@@ -20,15 +20,15 @@ import akka.NotUsed
 import akka.persistence.jdbc.config.JournalConfig
 import akka.persistence.jdbc.dao.JournalDao
 import akka.persistence.jdbc.dao.bytea.journal.JournalTables.JournalRow
-import akka.persistence.{AtomicWrite, PersistentRepr}
+import akka.persistence.{ AtomicWrite, PersistentRepr }
 import akka.serialization.Serialization
 import akka.stream.Materializer
-import akka.stream.scaladsl.{Flow, Source}
+import akka.stream.scaladsl.{ Flow, Source }
 import slick.driver.JdbcProfile
 import slick.jdbc.JdbcBackend._
 
-import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success, Try}
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.{ Failure, Success, Try }
 
 /**
  * The DefaultJournalDao contains all the knowledge to persist and load serialized journal entries

--- a/src/main/scala/akka/persistence/jdbc/dao/bytea/journal/ByteArrayJournalDao.scala
+++ b/src/main/scala/akka/persistence/jdbc/dao/bytea/journal/ByteArrayJournalDao.scala
@@ -20,6 +20,7 @@ import akka.NotUsed
 import akka.persistence.jdbc.config.JournalConfig
 import akka.persistence.jdbc.dao.JournalDao
 import akka.persistence.jdbc.dao.bytea.journal.JournalTables.JournalRow
+import akka.persistence.jdbc.serialization.FlowPersistentReprSerializer
 import akka.persistence.{ AtomicWrite, PersistentRepr }
 import akka.serialization.Serialization
 import akka.stream.Materializer
@@ -33,12 +34,15 @@ import scala.util.{ Failure, Success, Try }
 /**
  * The DefaultJournalDao contains all the knowledge to persist and load serialized journal entries
  */
-class ByteArrayJournalDao(db: Database, val profile: JdbcProfile, journalConfig: JournalConfig, serialization: Serialization)(implicit ec: ExecutionContext, mat: Materializer) extends JournalDao {
+trait BaseByteArrayJournalDao extends JournalDao {
+
+  val db: Database
+  val profile: JdbcProfile
+  val queries : JournalQueries
+  val serializer: FlowPersistentReprSerializer[JournalRow]
+  implicit val ec: ExecutionContext
+
   import profile.api._
-
-  val queries = new JournalQueries(profile, journalConfig.journalTableConfiguration, journalConfig.deletedToTableConfiguration)
-
-  val serializer = new ByteArrayJournalSerializer(serialization, journalConfig.pluginConfig.tagSeparator)
 
   private def futureExtractor: Flow[Try[Future[Unit]], Try[Unit], NotUsed] =
     Flow[Try[Future[Unit]]].mapAsync(1) {
@@ -75,11 +79,34 @@ class ByteArrayJournalDao(db: Database, val profile: JdbcProfile, journalConfig:
   }
 
   override def messages(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long): Source[Try[PersistentRepr], NotUsed] = {
-    val newMax = profile match {
-      case slick.driver.H2Driver ⇒ Math.min(max, Int.MaxValue) // H2 only accepts a Limit as an Integer
-      case _                     ⇒ max
-    }
-    Source.fromPublisher(db.stream(queries.messagesQuery(persistenceId, fromSequenceNr, toSequenceNr, newMax).result))
+    Source.fromPublisher(db.stream(queries.messagesQuery(persistenceId, fromSequenceNr, toSequenceNr, max).result))
       .via(serializer.deserializeFlowWithoutTags)
   }
 }
+
+trait H2JournalDao extends JournalDao {
+  val profile: JdbcProfile
+
+  private lazy val isH2Driver = profile match {
+    case slick.driver.H2Driver ⇒ true
+    case _                     ⇒ false
+  }
+
+  abstract override def messages(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long): Source[Try[PersistentRepr], NotUsed] = {
+    super.messages(persistenceId, fromSequenceNr, toSequenceNr, correctMaxForH2Driver(max))
+  }
+
+  private def correctMaxForH2Driver(max: Long): Long = {
+    if (isH2Driver) {
+      Math.min(max, Int.MaxValue) // H2 only accepts a LIMIT clause as an Integer
+    } else {
+      max
+    }
+  }
+}
+
+class ByteArrayJournalDao(val db: Database, val profile: JdbcProfile, journalConfig: JournalConfig, serialization: Serialization)(implicit val ec: ExecutionContext, val mat: Materializer) extends BaseByteArrayJournalDao with H2JournalDao {
+  val queries = new JournalQueries(profile, journalConfig.journalTableConfiguration, journalConfig.deletedToTableConfiguration)
+  val serializer = new ByteArrayJournalSerializer(serialization, journalConfig.pluginConfig.tagSeparator)
+}
+

--- a/src/main/scala/akka/persistence/jdbc/dao/bytea/journal/JournalQueries.scala
+++ b/src/main/scala/akka/persistence/jdbc/dao/bytea/journal/JournalQueries.scala
@@ -16,8 +16,8 @@
 
 package akka.persistence.jdbc.dao.bytea.journal
 
-import akka.persistence.jdbc.config.{DeletedToTableConfiguration, JournalTableConfiguration}
-import akka.persistence.jdbc.dao.bytea.journal.JournalTables.{JournalDeletedToRow, JournalRow}
+import akka.persistence.jdbc.config.{ DeletedToTableConfiguration, JournalTableConfiguration }
+import akka.persistence.jdbc.dao.bytea.journal.JournalTables.{ JournalDeletedToRow, JournalRow }
 import slick.driver.JdbcProfile
 
 class JournalQueries(val profile: JdbcProfile, override val journalTableCfg: JournalTableConfiguration, override val deletedToTableCfg: DeletedToTableConfiguration) extends JournalTables {
@@ -64,10 +64,10 @@ class JournalQueries(val profile: JdbcProfile, override val journalTableCfg: Jou
 
   private def _messagesQuery(persistenceId: Rep[String], fromSequenceNr: Rep[Long], toSequenceNr: Rep[Long], max: ConstColumn[Long]): Query[Journal, JournalRow, Seq] =
     JournalTable
-    .filter(_.persistenceId === persistenceId)
-    .filter(_.sequenceNumber >= fromSequenceNr)
-    .filter(_.sequenceNumber <= toSequenceNr)
-    .sortBy(_.sequenceNumber.asc)
-    .take(max)
+      .filter(_.persistenceId === persistenceId)
+      .filter(_.sequenceNumber >= fromSequenceNr)
+      .filter(_.sequenceNumber <= toSequenceNr)
+      .sortBy(_.sequenceNumber.asc)
+      .take(max)
   val messagesQuery = Compiled(_messagesQuery _)
 }

--- a/src/main/scala/akka/persistence/jdbc/dao/bytea/journal/JournalQueries.scala
+++ b/src/main/scala/akka/persistence/jdbc/dao/bytea/journal/JournalQueries.scala
@@ -62,15 +62,12 @@ class JournalQueries(val profile: JdbcProfile, override val journalTableCfg: Jou
       if query inSetBind persistenceIds
     } yield query
 
-  private def _unlimitedMessagesQuery(persistenceId: Rep[String], fromSequenceNr: Rep[Long], toSequenceNr: Rep[Long]): Query[Journal, JournalRow, Seq] =
+  private def _messagesQuery(persistenceId: Rep[String], fromSequenceNr: Rep[Long], toSequenceNr: Rep[Long], max: ConstColumn[Long]): Query[Journal, JournalRow, Seq] =
     JournalTable
     .filter(_.persistenceId === persistenceId)
     .filter(_.sequenceNumber >= fromSequenceNr)
     .filter(_.sequenceNumber <= toSequenceNr)
     .sortBy(_.sequenceNumber.asc)
-  val unlimitedMessagesQuery = Compiled(_unlimitedMessagesQuery _)
-
-  private def _messagesQuery(persistenceId: Rep[String], fromSequenceNr: Rep[Long], toSequenceNr: Rep[Long], max: ConstColumn[Long]): Query[Journal, JournalRow, Seq] =
-    _unlimitedMessagesQuery(persistenceId, fromSequenceNr, toSequenceNr).take(max)
+    .take(max)
   val messagesQuery = Compiled(_messagesQuery _)
 }

--- a/src/main/scala/akka/persistence/jdbc/dao/bytea/readjournal/ByteArrayReadJournalDao.scala
+++ b/src/main/scala/akka/persistence/jdbc/dao/bytea/readjournal/ByteArrayReadJournalDao.scala
@@ -21,6 +21,7 @@ import akka.persistence.PersistentRepr
 import akka.persistence.jdbc.config.ReadJournalConfig
 import akka.persistence.jdbc.dao.ReadJournalDao
 import akka.persistence.jdbc.dao.bytea.readjournal.ReadJournalTables.JournalRow
+import akka.persistence.jdbc.serialization.FlowPersistentReprSerializer
 import akka.serialization.Serialization
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
@@ -31,73 +32,110 @@ import slick.jdbc.JdbcBackend._
 import scala.concurrent.ExecutionContext
 import scala.util.Try
 
-class ByteArrayReadJournalDao(db: Database, val profile: JdbcProfile, readJournalConfig: ReadJournalConfig, serialization: Serialization)(implicit ec: ExecutionContext, mat: Materializer) extends ReadJournalDao {
+trait BaseByteArrayReadJournalDao extends ReadJournalDao {
+  val db: Database
+  val profile: JdbcProfile
+  val queries: ReadJournalQueries
+  val serializer: FlowPersistentReprSerializer[JournalRow]
+
   import profile.api._
-  val queries = new ReadJournalQueries(profile, readJournalConfig.journalTableConfiguration)
 
-  val serializer = new ByteArrayReadJournalSerializer(serialization, readJournalConfig.pluginConfig.tagSeparator)
-
-  private def oracleAllPersistenceIds(max: Long): Source[String, NotUsed] = {
-    import readJournalConfig.journalTableConfiguration._
-    import columnNames._
-    Source.fromPublisher(
-      db.stream(sql"""select distinct "#$persistenceId" from "#${schemaName.getOrElse("")}"."#$tableName" where rownum <= $max""".as[String])
-    )
-  }
-
-  private def defaultAllPersistenceIds(max: Long): Source[String, NotUsed] =
+  override def allPersistenceIdsSource(max: Long): Source[String, NotUsed] =
     Source.fromPublisher(db.stream(queries.allPersistenceIdsDistinct(max).result))
 
-  override def allPersistenceIdsSource(max: Long): Source[String, NotUsed] = profile match {
-    case com.typesafe.slick.driver.oracle.OracleDriver ⇒ oracleAllPersistenceIds(max)
-    case _                                             ⇒ defaultAllPersistenceIds(correctMaxForDBDriver(max))
+  override def eventsByTag(tag: String, offset: Long, max: Long): Source[Try[PersistentRepr], NotUsed] =
+    Source.fromPublisher(db.stream(queries.eventsByTag(s"%$tag%", Math.max(1, offset) - 1, max).result))
+      .via(serializer.deserializeFlowWithoutTags)
+
+  override def messages(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long): Source[Try[PersistentRepr], NotUsed] =
+    Source.fromPublisher(db.stream(queries.messagesQuery(persistenceId, fromSequenceNr, toSequenceNr,max).result))
+      .via(serializer.deserializeFlowWithoutTags)
+
+}
+
+trait OracleReadJournalDao extends ReadJournalDao {
+  val db: Database
+  val profile: JdbcProfile
+  val readJournalConfig: ReadJournalConfig
+  val queries: ReadJournalQueries
+  val serializer: FlowPersistentReprSerializer[JournalRow]
+
+  import profile.api._
+
+  private lazy val isOracleDriver = profile match {
+    case com.typesafe.slick.driver.oracle.OracleDriver ⇒ true
+    case _                                             ⇒ false
+  }
+
+  abstract override def allPersistenceIdsSource(max: Long): Source[String, NotUsed] = {
+    if (isOracleDriver) {
+      import readJournalConfig.journalTableConfiguration._
+      import columnNames._
+      Source.fromPublisher(
+        db.stream(sql"""select distinct "#$persistenceId" from "#${schemaName.getOrElse("")}"."#$tableName" where rownum <= $max""".as[String])
+      )
+    } else {
+      super.allPersistenceIdsSource(max)
+    }
   }
 
   implicit val getJournalRow = GetResult(r ⇒ JournalRow(r.<<, r.<<, r.nextBytes(), r.<<, r.<<))
 
-  private def oracleEventsByTag(tag: String, offset: Long, max: Long): Source[JournalRow, NotUsed] = {
-    import readJournalConfig.journalTableConfiguration._
-    import columnNames._
-    val theOffset = Math.max(1, offset) - 1
-    val theTag = s"%$tag%"
-    Source.fromPublisher(
-      db.stream(
-        sql"""SELECT "#$persistenceId", "#$sequenceNumber", "#$message", "#$created", "#$tags" FROM (
-              SELECT
-                a.*,
-                rownum rnum
-              FROM
-                (SELECT *
-                 FROM "#${schemaName.getOrElse("")}"."#$tableName"
-                 WHERE "#$tags" LIKE $theTag
-                 ORDER BY "#$created") a
-              where rownum <= $max
-            )
-            where rnum > $theOffset""".as[JournalRow]
-      )
-    )
-  }
-
-  private def defaultEventsByTag(tag: String, offset: Long, max: Long): Source[JournalRow, NotUsed] =
-    Source.fromPublisher(db.stream(queries.eventsByTag(s"%$tag%", Math.max(1, offset) - 1, correctMaxForDBDriver(max)).result))
-
-  override def eventsByTag(tag: String, offset: Long, max: Long): Source[Try[PersistentRepr], NotUsed] = {
-    val source: Source[JournalRow, NotUsed] = profile match {
-      case com.typesafe.slick.driver.oracle.OracleDriver ⇒ oracleEventsByTag(tag, offset, max)
-      case _                                             ⇒ defaultEventsByTag(tag, offset, max)
-    }
-    source.via(serializer.deserializeFlowWithoutTags)
-  }
-
-  override def messages(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long): Source[Try[PersistentRepr], NotUsed] =
-    Source.fromPublisher(db.stream(queries.messagesQuery(persistenceId, fromSequenceNr, toSequenceNr,
-                                                         correctMaxForDBDriver(max)).result))
-      .via(serializer.deserializeFlowWithoutTags)
-
-  private def correctMaxForDBDriver(max: Long): Long = {
-    profile match {
-      case slick.driver.H2Driver ⇒ Math.min(max, Int.MaxValue) // H2 only accepts a LIMIT clause as an Integer
-      case _                     ⇒ max
+  abstract override def eventsByTag(tag: String, offset: Long, max: Long): Source[Try[PersistentRepr], NotUsed] = {
+    if (isOracleDriver) {
+      import readJournalConfig.journalTableConfiguration._
+      import columnNames._
+      val theOffset = Math.max(1, offset) - 1
+      val theTag = s"%$tag%"
+      Source.fromPublisher(
+        db.stream(
+          sql"""SELECT "#$persistenceId", "#$sequenceNumber", "#$message", "#$created", "#$tags" FROM (
+                SELECT
+                  a.*,
+                  rownum rnum
+                FROM
+                  (SELECT *
+                   FROM "#${schemaName.getOrElse("")}"."#$tableName"
+                   WHERE "#$tags" LIKE $theTag
+                   ORDER BY "#$created") a
+                where rownum <= $max
+              )
+              where rnum > $theOffset""".as[JournalRow]
+        )
+      ).via(serializer.deserializeFlowWithoutTags)
+    } else {
+      super.eventsByTag(tag, offset, max)
     }
   }
+}
+
+trait H2ReadJournalDao extends ReadJournalDao {
+  val profile: JdbcProfile
+
+  private lazy val isH2Driver = profile match {
+    case slick.driver.H2Driver ⇒ true
+    case _                     ⇒ false
+  }
+
+  abstract override def allPersistenceIdsSource(max: Long): Source[String, NotUsed] =
+    super.allPersistenceIdsSource(correctMaxForH2Driver(max))
+
+  abstract override def eventsByTag(tag: String, offset: Long, max: Long): Source[Try[PersistentRepr], NotUsed] =
+    super.eventsByTag(tag, offset, correctMaxForH2Driver(max))
+
+  abstract override def messages(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long): Source[Try[PersistentRepr], NotUsed] =
+    super.messages(persistenceId, fromSequenceNr, toSequenceNr, correctMaxForH2Driver(max))
+
+  private def correctMaxForH2Driver(max: Long): Long = {
+    if (isH2Driver) {
+      Math.min(max, Int.MaxValue) // H2 only accepts a LIMIT clause as an Integer
+    } else {
+      max
+    }
+  }
+}
+
+class ByteArrayReadJournalDao(val db: Database, val profile: JdbcProfile, val readJournalConfig: ReadJournalConfig, serialization: Serialization) (implicit ec: ExecutionContext, mat: Materializer) extends BaseByteArrayReadJournalDao with OracleReadJournalDao with H2ReadJournalDao{
+  val queries = new ReadJournalQueries(profile, readJournalConfig.journalTableConfiguration)
+  val serializer = new ByteArrayReadJournalSerializer(serialization, readJournalConfig.pluginConfig.tagSeparator)
 }

--- a/src/test/resources/h2-application.conf
+++ b/src/test/resources/h2-application.conf
@@ -1,0 +1,53 @@
+# Copyright 2016 Dennis Vriend
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include "general.conf"
+
+jdbc-journal {
+  slick = ${slick}
+  slick.db.numThreads = 4
+  slick.db.maxConnections = 2
+  slick.db.minConnections = 1
+}
+
+# the akka-persistence-snapshot-store in use
+jdbc-snapshot-store {
+  slick = ${slick}
+  slick.db.numThreads = 4
+  slick.db.maxConnections = 2
+  slick.db.minConnections = 1
+}
+
+# the akka-persistence-query provider in use
+jdbc-read-journal {
+  refresh-interval = "100ms"
+
+  max-buffer-size = "500"
+
+  slick = ${slick}
+  slick.db.numThreads = 1
+  slick.db.maxConnections = 1
+  slick.db.minConnections = 1
+}
+
+slick {
+  driver = "slick.driver.H2Driver$"
+  db {
+    url = "jdbc:h2:mem:test-database;DATABASE_TO_UPPER=false;"
+    user = "root"
+    password = "root"
+    driver = "org.h2.Driver"
+    connectionTestQuery = "SELECT 1"
+  }
+}

--- a/src/test/scala/akka/persistence/jdbc/journal/JdbcJournalPerfSpec.scala
+++ b/src/test/scala/akka/persistence/jdbc/journal/JdbcJournalPerfSpec.scala
@@ -19,11 +19,11 @@ package akka.persistence.jdbc.journal
 import akka.persistence.CapabilityFlag
 import akka.persistence.jdbc.config._
 import akka.persistence.jdbc.util.Schema._
-import akka.persistence.jdbc.util.{ClasspathResources, DropCreate, SlickDatabase}
+import akka.persistence.jdbc.util.{ ClasspathResources, DropCreate, SlickDatabase }
 import akka.persistence.journal.JournalPerfSpec
-import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.config.{ Config, ConfigFactory }
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
+import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach }
 
 import scala.concurrent.duration._
 

--- a/src/test/scala/akka/persistence/jdbc/journal/JdbcJournalPerfSpec.scala
+++ b/src/test/scala/akka/persistence/jdbc/journal/JdbcJournalPerfSpec.scala
@@ -19,11 +19,11 @@ package akka.persistence.jdbc.journal
 import akka.persistence.CapabilityFlag
 import akka.persistence.jdbc.config._
 import akka.persistence.jdbc.util.Schema._
-import akka.persistence.jdbc.util.{ ClasspathResources, DropCreate, SlickDatabase }
+import akka.persistence.jdbc.util.{ClasspathResources, DropCreate, SlickDatabase}
 import akka.persistence.journal.JournalPerfSpec
-import com.typesafe.config.{ Config, ConfigFactory }
+import com.typesafe.config.{Config, ConfigFactory}
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach }
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 
 import scala.concurrent.duration._
 
@@ -92,6 +92,22 @@ class OracleJournalPerfSpec extends JdbcJournalPerfSpec(ConfigFactory.load("orac
 
   override def beforeAll(): Unit = {
     dropCreate(Oracle())
+    super.beforeAll()
+  }
+
+  override implicit def pc: PatienceConfig = PatienceConfig(timeout = 180.seconds)
+
+  override def awaitDurationMillis: Long = 180.seconds.toMillis
+
+  override def measurementIterations: Int = 1
+
+  override def eventsCount: Int = 1000 // oracle is very slow on my macbook / docker / virtualbox
+}
+
+class H2JournalPerfSpec extends JdbcJournalPerfSpec(ConfigFactory.load("h2-application.conf")) {
+
+  override def beforeAll(): Unit = {
+    dropCreate(H2())
     super.beforeAll()
   }
 

--- a/src/test/scala/akka/persistence/jdbc/journal/JdbcJournalPerfSpec.scala
+++ b/src/test/scala/akka/persistence/jdbc/journal/JdbcJournalPerfSpec.scala
@@ -27,7 +27,7 @@ import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 
 import scala.concurrent.duration._
 
-abstract class JdbcJournalPerfSpec(config: Config) extends JournalPerfSpec(config)
+abstract class JdbcJournalPerfSpec(config: Config, schemaType: SchemaType) extends JournalPerfSpec(config)
     with BeforeAndAfterAll
     with BeforeAndAfterEach
     with ScalaFutures
@@ -50,18 +50,18 @@ abstract class JdbcJournalPerfSpec(config: Config) extends JournalPerfSpec(confi
 
   val db = SlickDatabase.forConfig(cfg, journalConfig.slickConfiguration)
 
-  protected override def afterAll(): Unit = {
+  override def beforeAll(): Unit = {
+    dropCreate(schemaType)
+    super.beforeAll()
+  }
+
+  override def afterAll(): Unit = {
     db.close()
     super.afterAll()
   }
 }
 
-class PostgresJournalPerfSpec extends JdbcJournalPerfSpec(ConfigFactory.load("postgres-application.conf")) {
-
-  override def beforeAll(): Unit = {
-    dropCreate(Postgres())
-    super.beforeAll()
-  }
+class PostgresJournalPerfSpec extends JdbcJournalPerfSpec(ConfigFactory.load("postgres-application.conf"), Postgres()) {
 
   override implicit def pc: PatienceConfig = PatienceConfig(timeout = 30.seconds)
 
@@ -72,12 +72,7 @@ class PostgresJournalPerfSpec extends JdbcJournalPerfSpec(ConfigFactory.load("po
   override def eventsCount: Int = 1000 // postgres is very slow on my macbook / docker / virtualbox
 }
 
-class MySQLJournalPerfSpec extends JdbcJournalPerfSpec(ConfigFactory.load("mysql-application.conf")) {
-
-  override def beforeAll(): Unit = {
-    dropCreate(MySQL())
-    super.beforeAll()
-  }
+class MySQLJournalPerfSpec extends JdbcJournalPerfSpec(ConfigFactory.load("mysql-application.conf"), MySQL()) {
 
   override implicit def pc: PatienceConfig = PatienceConfig(timeout = 60.seconds)
 
@@ -88,12 +83,7 @@ class MySQLJournalPerfSpec extends JdbcJournalPerfSpec(ConfigFactory.load("mysql
   override def eventsCount: Int = 1000 // mysql is very slow on my macbook / docker / virtualbox
 }
 
-class OracleJournalPerfSpec extends JdbcJournalPerfSpec(ConfigFactory.load("oracle-application.conf")) {
-
-  override def beforeAll(): Unit = {
-    dropCreate(Oracle())
-    super.beforeAll()
-  }
+class OracleJournalPerfSpec extends JdbcJournalPerfSpec(ConfigFactory.load("oracle-application.conf"), Oracle()) {
 
   override implicit def pc: PatienceConfig = PatienceConfig(timeout = 180.seconds)
 
@@ -104,12 +94,7 @@ class OracleJournalPerfSpec extends JdbcJournalPerfSpec(ConfigFactory.load("orac
   override def eventsCount: Int = 1000 // oracle is very slow on my macbook / docker / virtualbox
 }
 
-class H2JournalPerfSpec extends JdbcJournalPerfSpec(ConfigFactory.load("h2-application.conf")) {
-
-  override def beforeAll(): Unit = {
-    dropCreate(H2())
-    super.beforeAll()
-  }
+class H2JournalPerfSpec extends JdbcJournalPerfSpec(ConfigFactory.load("h2-application.conf"), H2()) {
 
   override implicit def pc: PatienceConfig = PatienceConfig(timeout = 180.seconds)
 

--- a/src/test/scala/akka/persistence/jdbc/journal/JdbcJournalSpec.scala
+++ b/src/test/scala/akka/persistence/jdbc/journal/JdbcJournalSpec.scala
@@ -80,3 +80,10 @@ class OracleJournalSpec extends JdbcJournalSpec(ConfigFactory.load("oracle-appli
     super.beforeAll()
   }
 }
+
+class H2JournalSpec extends JdbcJournalSpec(ConfigFactory.load("h2-application.conf")) {
+  override def beforeAll(): Unit = {
+    dropCreate(H2())
+    super.beforeAll()
+  }
+}

--- a/src/test/scala/akka/persistence/jdbc/journal/JdbcJournalSpec.scala
+++ b/src/test/scala/akka/persistence/jdbc/journal/JdbcJournalSpec.scala
@@ -27,7 +27,7 @@ import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach }
 
 import scala.concurrent.duration._
 
-abstract class JdbcJournalSpec(config: Config) extends JournalSpec(config)
+abstract class JdbcJournalSpec(config: Config, schemaType: SchemaType) extends JournalSpec(config)
     with BeforeAndAfterAll
     with BeforeAndAfterEach
     with ScalaFutures
@@ -46,7 +46,12 @@ abstract class JdbcJournalSpec(config: Config) extends JournalSpec(config)
 
   val db = SlickDatabase.forConfig(cfg, journalConfig.slickConfiguration)
 
-  protected override def afterAll(): Unit = {
+  override def beforeAll(): Unit = {
+    dropCreate(schemaType)
+    super.beforeAll()
+  }
+
+  override def afterAll(): Unit = {
     db.close()
     super.afterAll()
   }
@@ -56,34 +61,14 @@ abstract class JdbcJournalSpec(config: Config) extends JournalSpec(config)
  * Use the postgres DDL script that is available on the website, for some reason slick generates incorrect DDL,
  * but the Slick Tables definition must not change, else it breaks the UPSERT feature...
  */
-class PostgresJournalSpec extends JdbcJournalSpec(ConfigFactory.load("postgres-application.conf")) {
-  override def beforeAll(): Unit = {
-    dropCreate(Postgres())
-    super.beforeAll()
-  }
-}
+class PostgresJournalSpec extends JdbcJournalSpec(ConfigFactory.load("postgres-application.conf"), Postgres())
 
 /**
  * Does not (yet) work because Slick generates double quotes to escape field names
  * for some reason when creating the DDL
  */
-class MySQLJournalSpec extends JdbcJournalSpec(ConfigFactory.load("mysql-application.conf")) {
-  override def beforeAll(): Unit = {
-    dropCreate(MySQL())
-    super.beforeAll()
-  }
-}
+class MySQLJournalSpec extends JdbcJournalSpec(ConfigFactory.load("mysql-application.conf"), MySQL())
 
-class OracleJournalSpec extends JdbcJournalSpec(ConfigFactory.load("oracle-application.conf")) {
-  override def beforeAll(): Unit = {
-    dropCreate(Oracle())
-    super.beforeAll()
-  }
-}
+class OracleJournalSpec extends JdbcJournalSpec(ConfigFactory.load("oracle-application.conf"), Oracle())
 
-class H2JournalSpec extends JdbcJournalSpec(ConfigFactory.load("h2-application.conf")) {
-  override def beforeAll(): Unit = {
-    dropCreate(H2())
-    super.beforeAll()
-  }
-}
+class H2JournalSpec extends JdbcJournalSpec(ConfigFactory.load("h2-application.conf"), H2())

--- a/src/test/scala/akka/persistence/jdbc/query/AllPersistenceIdsTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/AllPersistenceIdsTest.scala
@@ -16,8 +16,6 @@
 
 package akka.persistence.jdbc.query
 
-import akka.persistence.jdbc.util.Schema.{ MySQL, Oracle, Postgres }
-
 import scala.concurrent.duration._
 
 abstract class AllPersistenceIdsTest(config: String) extends QueryTestSpec(config) {
@@ -62,23 +60,13 @@ abstract class AllPersistenceIdsTest(config: String) extends QueryTestSpec(confi
     }
 }
 
-class PostgresScalaAllPersistenceIdsTest extends AllPersistenceIdsTest("postgres-application.conf") with ScalaJdbcReadJournalOperations {
-  dropCreate(Postgres())
-}
+class PostgresScalaAllPersistenceIdsTest extends AllPersistenceIdsTest("postgres-application.conf") with ScalaJdbcReadJournalOperations with PostgresCleaner
 
-class MySQLScalaAllPersistenceIdsTest extends AllPersistenceIdsTest("mysql-application.conf") with ScalaJdbcReadJournalOperations {
-  dropCreate(MySQL())
-}
+class MySQLScalaAllPersistenceIdsTest extends AllPersistenceIdsTest("mysql-application.conf") with ScalaJdbcReadJournalOperations with MysqlCleaner
 
-class OracleScalaAllPersistenceIdsTest extends AllPersistenceIdsTest("oracle-application.conf") with ScalaJdbcReadJournalOperations {
-  dropCreate(Oracle())
+class OracleScalaAllPersistenceIdsTest extends AllPersistenceIdsTest("oracle-application.conf") with ScalaJdbcReadJournalOperations with OracleCleaner
 
-  protected override def beforeEach(): Unit =
-    clearOracle()
-
-  override protected def afterAll(): Unit =
-    clearOracle()
-}
+class H2ScalaAllPersistenceIdsTest extends AllPersistenceIdsTest("h2-application.conf") with ScalaJdbcReadJournalOperations with H2Cleaner
 
 //class PostgresJavaAllPersistenceIdsTest extends AllPersistenceIdsTest("postgres-application.conf") with JavaDslJdbcReadJournalOperations {
 //  dropCreate(Postgres())

--- a/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByPersistenceIdTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByPersistenceIdTest.scala
@@ -16,7 +16,6 @@
 
 package akka.persistence.jdbc.query
 
-import akka.persistence.jdbc.util.Schema.{ MySQL, Oracle, Postgres }
 import akka.persistence.query.EventEnvelope
 
 abstract class CurrentEventsByPersistenceIdTest(config: String) extends QueryTestSpec(config) {
@@ -131,23 +130,13 @@ abstract class CurrentEventsByPersistenceIdTest(config: String) extends QueryTes
     }
 }
 
-class PostgresScalaCurrentEventsByPersistenceIdTest extends CurrentEventsByPersistenceIdTest("postgres-application.conf") with ScalaJdbcReadJournalOperations {
-  dropCreate(Postgres())
-}
+class PostgresScalaCurrentEventsByPersistenceIdTest extends CurrentEventsByPersistenceIdTest("postgres-application.conf") with ScalaJdbcReadJournalOperations with PostgresCleaner
 
-class MySQLScalaCurrentEventsByPersistenceIdTest extends CurrentEventsByPersistenceIdTest("mysql-application.conf") with ScalaJdbcReadJournalOperations {
-  dropCreate(MySQL())
-}
+class MySQLScalaCurrentEventsByPersistenceIdTest extends CurrentEventsByPersistenceIdTest("mysql-application.conf") with ScalaJdbcReadJournalOperations with MysqlCleaner
 
-class OracleScalaCurrentEventsByPersistenceIdTest extends CurrentEventsByPersistenceIdTest("oracle-application.conf") with ScalaJdbcReadJournalOperations {
-  dropCreate(Oracle())
+class OracleScalaCurrentEventsByPersistenceIdTest extends CurrentEventsByPersistenceIdTest("oracle-application.conf") with ScalaJdbcReadJournalOperations with OracleCleaner
 
-  protected override def beforeEach(): Unit =
-    clearOracle()
-
-  override protected def afterAll(): Unit =
-    clearOracle()
-}
+class H2ScalaCurrentEventsByPersistenceIdTest extends CurrentEventsByPersistenceIdTest("h2-application.conf") with ScalaJdbcReadJournalOperations with H2Cleaner
 
 //class PostgresJavaCurrentEventsByPersistenceIdTest extends CurrentEventsByPersistenceIdTest("postgres-application.conf") with JavaDslJdbcReadJournalOperations {
 //  dropCreate(Postgres())

--- a/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByTagTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByTagTest.scala
@@ -16,7 +16,6 @@
 
 package akka.persistence.jdbc.query
 
-import akka.persistence.jdbc.util.Schema.{ MySQL, Oracle, Postgres }
 import akka.persistence.query.EventEnvelope
 
 abstract class CurrentEventsByTagTest(config: String) extends QueryTestSpec(config) {
@@ -145,23 +144,13 @@ abstract class CurrentEventsByTagTest(config: String) extends QueryTestSpec(conf
     }
 }
 
-class PostgresScalaCurrentEventsByTagTest extends CurrentEventsByTagTest("postgres-application.conf") with ScalaJdbcReadJournalOperations {
-  dropCreate(Postgres())
-}
+class PostgresScalaCurrentEventsByTagTest extends CurrentEventsByTagTest("postgres-application.conf") with ScalaJdbcReadJournalOperations with PostgresCleaner
 
-class MySQLScalaCurrentEventsByTagTest extends CurrentEventsByTagTest("mysql-application.conf") with ScalaJdbcReadJournalOperations {
-  dropCreate(MySQL())
-}
+class MySQLScalaCurrentEventsByTagTest extends CurrentEventsByTagTest("mysql-application.conf") with ScalaJdbcReadJournalOperations with MysqlCleaner
 
-class OracleScalaCurrentEventsByTagTest extends CurrentEventsByTagTest("oracle-application.conf") with ScalaJdbcReadJournalOperations {
-  dropCreate(Oracle())
+class OracleScalaCurrentEventsByTagTest extends CurrentEventsByTagTest("oracle-application.conf") with ScalaJdbcReadJournalOperations with OracleCleaner
 
-  protected override def beforeEach(): Unit =
-    clearOracle()
-
-  override protected def afterAll(): Unit =
-    clearOracle()
-}
+class H2ScalaCurrentEventsByTagTest extends CurrentEventsByTagTest("h2-application.conf") with ScalaJdbcReadJournalOperations with H2Cleaner
 
 //class PostgresJavaCurrentEventsByTagTest extends CurrentEventsByTagTest("postgres-application.conf") with JavaDslJdbcReadJournalOperations {
 //  dropCreate(Postgres())

--- a/src/test/scala/akka/persistence/jdbc/query/CurrentPersistenceIdsTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/CurrentPersistenceIdsTest.scala
@@ -16,8 +16,6 @@
 
 package akka.persistence.jdbc.query
 
-import akka.persistence.jdbc.util.Schema.{ MySQL, Oracle, Postgres }
-
 abstract class CurrentPersistenceIdsTest(config: String) extends QueryTestSpec(config) {
 
   it should "not find any persistenceIds for empty journal" in
@@ -42,23 +40,13 @@ abstract class CurrentPersistenceIdsTest(config: String) extends QueryTestSpec(c
     }
 }
 
-class PostgresScalaCurrentPersistenceIdsTest extends CurrentPersistenceIdsTest("postgres-application.conf") with ScalaJdbcReadJournalOperations {
-  dropCreate(Postgres())
-}
+class PostgresScalaCurrentPersistenceIdsTest extends CurrentPersistenceIdsTest("postgres-application.conf") with ScalaJdbcReadJournalOperations with PostgresCleaner
 
-class MySQLScalaCurrentPersistenceIdsTest extends CurrentPersistenceIdsTest("mysql-application.conf") with ScalaJdbcReadJournalOperations {
-  dropCreate(MySQL())
-}
+class MySQLScalaCurrentPersistenceIdsTest extends CurrentPersistenceIdsTest("mysql-application.conf") with ScalaJdbcReadJournalOperations with MysqlCleaner
 
-class OracleScalaCurrentPersistenceIdsTest extends CurrentPersistenceIdsTest("oracle-application.conf") with ScalaJdbcReadJournalOperations {
-  dropCreate(Oracle())
+class OracleScalaCurrentPersistenceIdsTest extends CurrentPersistenceIdsTest("oracle-application.conf") with ScalaJdbcReadJournalOperations with OracleCleaner
 
-  protected override def beforeEach(): Unit =
-    clearOracle()
-
-  override protected def afterAll(): Unit =
-    clearOracle()
-}
+class H2ScalaCurrentPersistenceIdsTest extends CurrentPersistenceIdsTest("h2-application.conf") with ScalaJdbcReadJournalOperations with H2Cleaner
 
 //class PostgresJavaCurrentPersistenceIdsTest extends CurrentPersistenceIdsTest("postgres-application.conf") with JavaDslJdbcReadJournalOperations {
 //  dropCreate(Postgres())

--- a/src/test/scala/akka/persistence/jdbc/query/EventsByPersistenceIdTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/EventsByPersistenceIdTest.scala
@@ -16,7 +16,6 @@
 
 package akka.persistence.jdbc.query
 
-import akka.persistence.jdbc.util.Schema.{ MySQL, Oracle, Postgres }
 import akka.persistence.query.EventEnvelope
 
 import scala.concurrent.duration._
@@ -198,23 +197,13 @@ abstract class EventsByPersistenceIdTest(config: String) extends QueryTestSpec(c
   }
 }
 
-class PostgresScalaEventsByPersistenceIdTest extends EventsByPersistenceIdTest("postgres-application.conf") with ScalaJdbcReadJournalOperations {
-  dropCreate(Postgres())
-}
+class PostgresScalaEventsByPersistenceIdTest extends EventsByPersistenceIdTest("postgres-application.conf") with ScalaJdbcReadJournalOperations with PostgresCleaner
 
-class MySQLScalaEventsByPersistenceIdTest extends EventsByPersistenceIdTest("mysql-application.conf") with ScalaJdbcReadJournalOperations {
-  dropCreate(MySQL())
-}
+class MySQLScalaEventsByPersistenceIdTest extends EventsByPersistenceIdTest("mysql-application.conf") with ScalaJdbcReadJournalOperations with MysqlCleaner
 
-class OracleScalaEventsByPersistenceIdTest extends EventsByPersistenceIdTest("oracle-application.conf") with ScalaJdbcReadJournalOperations {
-  dropCreate(Oracle())
+class OracleScalaEventsByPersistenceIdTest extends EventsByPersistenceIdTest("oracle-application.conf") with ScalaJdbcReadJournalOperations with OracleCleaner
 
-  protected override def beforeEach(): Unit =
-    clearOracle()
-
-  override protected def afterAll(): Unit =
-    clearOracle()
-}
+class H2ScalaEventsByPersistenceIdTest extends EventsByPersistenceIdTest("h2-application.conf") with ScalaJdbcReadJournalOperations with H2Cleaner
 
 //class PostgresJavaEventsByPersistenceIdTest extends EventsByPersistenceIdTest("postgres-application.conf") with JavaDslJdbcReadJournalOperations {
 //  dropCreate(Postgres())

--- a/src/test/scala/akka/persistence/jdbc/query/EventsByTagTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/EventsByTagTest.scala
@@ -16,7 +16,6 @@
 
 package akka.persistence.jdbc.query
 
-import akka.persistence.jdbc.util.Schema.{ Oracle, MySQL, Postgres }
 import akka.persistence.query.EventEnvelope
 import scala.concurrent.duration._
 
@@ -227,23 +226,13 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config) {
   }
 }
 
-class PostgresScalaEventsByTagTest extends EventsByTagTest("postgres-application.conf") with ScalaJdbcReadJournalOperations {
-  dropCreate(Postgres())
-}
+class PostgresScalaEventsByTagTest extends EventsByTagTest("postgres-application.conf") with ScalaJdbcReadJournalOperations with PostgresCleaner
 
-class MySQLScalaEventByTagTest extends EventsByTagTest("mysql-application.conf") with ScalaJdbcReadJournalOperations {
-  dropCreate(MySQL())
-}
+class MySQLScalaEventByTagTest extends EventsByTagTest("mysql-application.conf") with ScalaJdbcReadJournalOperations with MysqlCleaner
 
-class OracleScalaEventByTagTest extends EventsByTagTest("oracle-application.conf") with ScalaJdbcReadJournalOperations {
-  dropCreate(Oracle())
+class OracleScalaEventByTagTest extends EventsByTagTest("oracle-application.conf") with ScalaJdbcReadJournalOperations with OracleCleaner
 
-  protected override def beforeEach(): Unit =
-    clearOracle()
-
-  override protected def afterAll(): Unit =
-    clearOracle()
-}
+class H2ScalaEventsByTagTest extends EventsByTagTest("h2-application.conf") with ScalaJdbcReadJournalOperations with H2Cleaner
 
 //class PostgresJavaEventsByTagTest extends EventsByTagTest("postgres-application.conf") with JavaDslJdbcReadJournalOperations {
 //  dropCreate(Postgres())

--- a/src/test/scala/akka/persistence/jdbc/snapshot/JdbcSnapshotStoreSpec.scala
+++ b/src/test/scala/akka/persistence/jdbc/snapshot/JdbcSnapshotStoreSpec.scala
@@ -26,7 +26,7 @@ import org.scalatest.concurrent.ScalaFutures
 
 import scala.concurrent.duration._
 
-abstract class JdbcSnapshotStoreSpec(config: Config) extends SnapshotStoreSpec(config) with BeforeAndAfterAll with ScalaFutures with ClasspathResources with DropCreate {
+abstract class JdbcSnapshotStoreSpec(config: Config, schemaType: SchemaType) extends SnapshotStoreSpec(config) with BeforeAndAfterAll with ScalaFutures with ClasspathResources with DropCreate {
 
   implicit val pc: PatienceConfig = PatienceConfig(timeout = 10.seconds)
 
@@ -37,16 +37,17 @@ abstract class JdbcSnapshotStoreSpec(config: Config) extends SnapshotStoreSpec(c
   val journalConfig = new JournalConfig(cfg)
 
   val db = SlickDatabase.forConfig(cfg, journalConfig.slickConfiguration)
+
+  override def beforeAll() : Unit = {
+    dropCreate(schemaType)
+    super.beforeAll()
+  }
 }
 
-class PostgresSnapshotStoreSpec extends JdbcSnapshotStoreSpec(ConfigFactory.load("postgres-application.conf")) {
-  dropCreate(Postgres())
-}
+class PostgresSnapshotStoreSpec extends JdbcSnapshotStoreSpec(ConfigFactory.load("postgres-application.conf"), Postgres())
 
-class MySQLSnapshotStoreSpec extends JdbcSnapshotStoreSpec(ConfigFactory.load("mysql-application.conf")) {
-  dropCreate(MySQL())
-}
+class MySQLSnapshotStoreSpec extends JdbcSnapshotStoreSpec(ConfigFactory.load("mysql-application.conf"), MySQL())
 
-class OracleSnapshotStoreSpec extends JdbcSnapshotStoreSpec(ConfigFactory.load("oracle-application.conf")) {
-  dropCreate(Oracle())
-}
+class OracleSnapshotStoreSpec extends JdbcSnapshotStoreSpec(ConfigFactory.load("oracle-application.conf"), Oracle())
+
+class H2SnapshotStoreSpec extends JdbcSnapshotStoreSpec(ConfigFactory.load("h2-application.conf"), H2())

--- a/src/test/scala/akka/persistence/jdbc/util/DropCreate.scala
+++ b/src/test/scala/akka/persistence/jdbc/util/DropCreate.scala
@@ -26,6 +26,7 @@ object Schema {
 
   sealed trait SchemaType { def schema: String }
   final case class Postgres(schema: String = "schema/postgres/postgres-schema.sql") extends SchemaType
+  final case class H2(schema: String = "schema/h2/h2-schema.sql") extends SchemaType
   final case class MySQL(schema: String = "schema/mysql/mysql-schema.sql") extends SchemaType
   final case class Oracle(schema: String = "schema/oracle/oracle-schema.sql") extends SchemaType
 }


### PR DESCRIPTION
Introduces the capability to use H2 as a DB.

It adds all the tests for it (and I revamped them a bit to avoid duplication).

H2 is particularly useful for component testing without the need of having a docker container already running :)

Please check my last commit. It was kind of an experiment (using stackable traits). In my view it makes things a bit cleaner (with separation of concerns for each driver), and technically it's even (a tiny bit) more performant (negligible).
I found it interesting how in the base traits it showed that not as much inputs were needed :) 