### PR TITLE
Fixed invalid journal table name when schemaName config is empty

### DIFF
--- a/src/main/scala/akka/persistence/jdbc/config/AkkaPersistenceConfig.scala
+++ b/src/main/scala/akka/persistence/jdbc/config/AkkaPersistenceConfig.scala
@@ -44,6 +44,7 @@ class JournalTableConfiguration(config: Config) {
   private val cfg = config.asConfig("tables.journal")
   val tableName: String = cfg.as[String]("tableName", "journal")
   val schemaName: Option[String] = cfg.as[String]("schemaName").trim
+  val fullTableName = schemaName.map(_ + ".").getOrElse("") + tableName
   val columnNames: JournalTableColumnNames = new JournalTableColumnNames(config)
   override def toString: String = s"JournalTableConfiguration($tableName,$schemaName,$columnNames)"
 }
@@ -59,6 +60,7 @@ class DeletedToTableConfiguration(config: Config) {
   private val cfg = config.asConfig("tables.deletedTo")
   val tableName: String = cfg.as[String]("tableName", "deleted_to")
   val schemaName: Option[String] = cfg.as[String]("schemaName").trim
+  val fullTableName = schemaName.map(_ + ".").getOrElse("") + tableName
   val columnNames: DeletedToTableColumnNames = new DeletedToTableColumnNames(config)
   override def toString: String = s"DeletedToTableConfiguration($tableName,$schemaName,$columnNames)"
 }
@@ -76,6 +78,7 @@ class SnapshotTableConfiguration(config: Config) {
   private val cfg = config.asConfig("tables.snapshot")
   val tableName: String = cfg.as[String]("tableName", "snapshot")
   val schemaName: Option[String] = cfg.as[String]("schemaName").trim
+  val fullTableName = schemaName.map(_ + ".").getOrElse("") + tableName
   val columnNames: SnapshotTableColumnNames = new SnapshotTableColumnNames(config)
   override def toString: String = s"SnapshotTableConfiguration($tableName,$schemaName,$columnNames)"
 }

--- a/src/main/scala/akka/persistence/jdbc/dao/bytea/readjournal/ByteArrayReadJournalDao.scala
+++ b/src/main/scala/akka/persistence/jdbc/dao/bytea/readjournal/ByteArrayReadJournalDao.scala
@@ -71,7 +71,7 @@ trait OracleReadJournalDao extends ReadJournalDao {
       import readJournalConfig.journalTableConfiguration._
       import columnNames._
       Source.fromPublisher(
-        db.stream(sql"""select distinct "#$persistenceId" from "#${schemaName.getOrElse("")}"."#$tableName" where rownum <= $max""".as[String])
+        db.stream(sql"""select distinct "#$persistenceId" from "#$fullTableName" where rownum <= $max""".as[String])
       )
     } else {
       super.allPersistenceIdsSource(max)
@@ -94,7 +94,7 @@ trait OracleReadJournalDao extends ReadJournalDao {
                   rownum rnum
                 FROM
                   (SELECT *
-                   FROM "#${schemaName.getOrElse("")}"."#$tableName"
+                   FROM "#$fullTableName"
                    WHERE "#$tags" LIKE $theTag
                    ORDER BY "#$ordering") a
                 where rownum <= $max


### PR DESCRIPTION
In case the `schemaName` config is empty, `#${schemaName.getOrElse("")}"."#$tableName` will result in `.tableName` instead of just `tableName`.
Added a `fullTableName` value to config that omits the `.` in case of empty `schemaName`.