### PR TITLE
Sql optimizations

### DIFF
--- a/src/main/resources/schema/h2/h2-schema.sql
+++ b/src/main/resources/schema/h2/h2-schema.sql
@@ -10,6 +10,8 @@ CREATE TABLE IF NOT EXISTS PUBLIC.journal (
   PRIMARY KEY(ordering, persistence_id, sequence_number)
 );
 
+CREATE INDEX journal_persistence_id_sequence_number_idx ON PUBLIC.journal(persistence_id, sequence_number);
+
 DROP TABLE IF EXISTS PUBLIC.snapshot;
 
 CREATE TABLE IF NOT EXISTS PUBLIC.snapshot (

--- a/src/main/resources/schema/mysql/mysql-schema.sql
+++ b/src/main/resources/schema/mysql/mysql-schema.sql
@@ -10,6 +10,8 @@ CREATE TABLE IF NOT EXISTS journal (
   PRIMARY KEY(ordering, persistence_id, sequence_number)
 );
 
+CREATE INDEX journal_persistence_id_sequence_number_idx ON journal(persistence_id, sequence_number);
+
 DROP TABLE IF EXISTS snapshot;
 
 CREATE TABLE IF NOT EXISTS snapshot (

--- a/src/main/resources/schema/oracle/oracle-schema.sql
+++ b/src/main/resources/schema/oracle/oracle-schema.sql
@@ -11,6 +11,8 @@ CREATE TABLE "journal" (
   PRIMARY KEY("ordering", "persistence_id", "sequence_number")
 );
 
+CREATE INDEX "journal_persistence_id_sequence_number_idx" ON "journal"("persistence_id", "sequence_number");
+
 CREATE TRIGGER "ordering_seq_trigger"
 BEFORE INSERT ON "journal"
 FOR EACH ROW

--- a/src/main/resources/schema/postgres/postgres-schema.sql
+++ b/src/main/resources/schema/postgres/postgres-schema.sql
@@ -10,6 +10,8 @@ CREATE TABLE IF NOT EXISTS public.journal (
   PRIMARY KEY(ordering, persistence_id, sequence_number)
 );
 
+CREATE INDEX journal_persistence_id_sequence_number_idx ON public.journal(persistence_id, sequence_number);
+
 DROP TABLE IF EXISTS public.snapshot;
 
 CREATE TABLE IF NOT EXISTS public.snapshot (

--- a/src/main/scala/akka/persistence/jdbc/dao/bytea/journal/ByteArrayJournalDao.scala
+++ b/src/main/scala/akka/persistence/jdbc/dao/bytea/journal/ByteArrayJournalDao.scala
@@ -65,7 +65,7 @@ trait BaseByteArrayJournalDao extends JournalDao {
     db.run(queries.markJournalMessagesAsDeleted(persistenceId, maxSequenceNr)).map(_ => ())
 
   override def highestSequenceNr(persistenceId: String, fromSequenceNr: Long): Future[Long] =
-    db.run(queries.highestSequenceNrForPersistenceId(persistenceId).result).map(_.getOrElse(0L))
+    db.run(queries.highestSequenceNrForPersistenceId(persistenceId).result.headOption).map(_.getOrElse(0L))
 
   override def messages(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long): Source[Try[PersistentRepr], NotUsed] =
     Source.fromPublisher(db.stream(queries.messagesQuery(persistenceId, fromSequenceNr, toSequenceNr, max).result))

--- a/src/main/scala/akka/persistence/jdbc/dao/bytea/journal/JournalQueries.scala
+++ b/src/main/scala/akka/persistence/jdbc/dao/bytea/journal/JournalQueries.scala
@@ -34,8 +34,8 @@ class JournalQueries(val profile: JdbcProfile, override val journalTableCfg: Jou
     JournalTable.filter(_.persistenceId === persistenceId).filter(_.sequenceNumber <= maxSequenceNr)
       .map(_.deleted).update(true)
 
-  private def _highestSequenceNrForPersistenceId(persistenceId: Rep[String]): Rep[Option[Long]] =
-    selectAllJournalForPersistenceId(persistenceId).map(_.sequenceNumber).max
+  private def _highestSequenceNrForPersistenceId(persistenceId: Rep[String]): Query[Rep[Long], Long, Seq] =
+    selectAllJournalForPersistenceId(persistenceId).map(_.sequenceNumber).take(1)
 
   val highestSequenceNrForPersistenceId = Compiled(_highestSequenceNrForPersistenceId _)
 

--- a/src/main/scala/akka/persistence/jdbc/dao/bytea/snapshot/SnapshotQueries.scala
+++ b/src/main/scala/akka/persistence/jdbc/dao/bytea/snapshot/SnapshotQueries.scala
@@ -23,9 +23,6 @@ import slick.driver.JdbcProfile
 class SnapshotQueries(val profile: JdbcProfile, override val snapshotTableCfg: SnapshotTableConfiguration) extends SnapshotTables {
   import profile.api._
 
-  private def maxSeqNrForPersistenceId(persistenceId: Rep[String]) =
-    _selectAll(persistenceId).map(_.sequenceNumber).max
-
   def insertOrUpdate(snapshotRow: SnapshotRow) =
     SnapshotTable.insertOrUpdate(snapshotRow)
 
@@ -34,7 +31,7 @@ class SnapshotQueries(val profile: JdbcProfile, override val snapshotTableCfg: S
   val selectAll = Compiled(_selectAll _)
 
   private def _selectByPersistenceIdAndMaxSeqNr(persistenceId: Rep[String]) =
-    _selectAll(persistenceId).filter(_.sequenceNumber === maxSeqNrForPersistenceId(persistenceId))
+    _selectAll(persistenceId).take(1)
   val selectByPersistenceIdAndMaxSeqNr = Compiled(_selectByPersistenceIdAndMaxSeqNr _)
 
   private def _selectByPersistenceIdAndSeqNr(persistenceId: Rep[String], sequenceNr: Rep[Long]) =


### PR DESCRIPTION
I recently noticed recovery time degradation with growth of journal table. One of unnecessarily slow queries I found was selection of last sequence number for both journal and snapshot.

```
selectAllJournalForPersistenceId(persistenceId).map(_.sequenceNumber).max 
```
translates into this sql:

```
select max(jour.sequence_number) from (select persistence_id, sequence_number from journal where persistence_id = 'Neighbour-10' order by sequence_number desc) jour;
```

which will become slower with growth of persisted events for given persistence_id(1+ seconds on journal with total 5 000 000 records), whereas all we need is to get last sequence_number. Simpler equivalent request is:

```
selectAllJournalForPersistenceId(persistenceId).map(_.sequenceNumber).take(1) 
```

translates into this sql:
```
select sequence_number from journal where persistence_id = 'Neighbour-10' order by sequence_number desc limit 1;
```

Same changes applied to snapshot queries.

Also, because there are a lot of queries filtered by `persistence_id` and `sequence_number` in journal table index on (persistence_id, sequence_number) required.
