### PR TITLE
Snapshot table should only define one primary key

### DIFF
--- a/src/main/scala/akka/persistence/jdbc/snapshot/dao/SnapshotTables.scala
+++ b/src/main/scala/akka/persistence/jdbc/snapshot/dao/SnapshotTables.scala
@@ -39,8 +39,8 @@ trait SnapshotTables {
   class Snapshot(_tableTag: Tag) extends Table[SnapshotRow](_tableTag, _schemaName = snapshotTableCfg.schemaName, _tableName = snapshotTableCfg.tableName) {
     def * = (persistenceId, sequenceNumber, created, snapshot) <> (SnapshotRow.tupled, SnapshotRow.unapply)
 
-    val persistenceId: Rep[String] = column[String](snapshotTableCfg.columnNames.persistenceId, O.Length(255, varying = true), O.PrimaryKey)
-    val sequenceNumber: Rep[Long] = column[Long](snapshotTableCfg.columnNames.sequenceNumber, O.PrimaryKey)
+    val persistenceId: Rep[String] = column[String](snapshotTableCfg.columnNames.persistenceId, O.Length(255, varying = true))
+    val sequenceNumber: Rep[Long] = column[Long](snapshotTableCfg.columnNames.sequenceNumber)
     val created: Rep[Long] = column[Long](snapshotTableCfg.columnNames.created)
     val snapshot: Rep[Array[Byte]] = column[Array[Byte]](snapshotTableCfg.columnNames.snapshot)
     val pk = primaryKey("snapshot_pk", (persistenceId, sequenceNumber))


### PR DESCRIPTION
Fixes #71.
