### PR TITLE
Removed binary dependency on slick-extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,16 @@ Akka-persistence-jdbc writes journal and snapshot entries entries to a configure
 Add the following to your `build.sbt`:
 
 ```scala
+libraryDependencies += "com.github.dnvriend" %% "akka-persistence-jdbc" % "2.6.6"
+```
+
+If using Oracle, you'll also need the Slick Oracle driver:
+
+```scala
 // to resolve the slick-extensions you need the following repo
 resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/maven-releases/"
 
-// akka-persistence-jdbc is available in Bintray's JCenter
-resolvers += Resolver.jcenterRepo
-
-libraryDependencies += "com.github.dnvriend" %% "akka-persistence-jdbc" % "2.6.6"
+libraryDependencies += "com.typesafe.slick" %% "slick-extensions" % "3.1.0"
 ```
 
 ## Contribution policy

--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ libraryDependencies ++= {
     "com.github.dnvriend" %% "akka-persistence-query-writer" % "0.0.2",
     "com.typesafe.akka" %% "akka-stream" % akkaVersion,
     "com.typesafe.slick" %% "slick" % slickVersion,
-    "com.typesafe.slick" %% "slick-extensions" % "3.1.0",
+    "com.typesafe.slick" %% "slick-extensions" % "3.1.0" % Test,
     "com.typesafe.slick" %% "slick-hikaricp" % slickVersion exclude("com.zaxxer", "HikariCP-java6"),
     "com.zaxxer" % "HikariCP" % hikariCPVersion,
     "com.github.dnvriend" %% "akka-stream-extensions" % "0.0.2" % Test,

--- a/src/main/scala/akka/persistence/jdbc/dao/bytea/readjournal/ByteArrayReadJournalDao.scala
+++ b/src/main/scala/akka/persistence/jdbc/dao/bytea/readjournal/ByteArrayReadJournalDao.scala
@@ -82,10 +82,7 @@ trait OracleReadJournalDao extends ReadJournalDao {
 
   import profile.api._
 
-  private lazy val isOracleDriver = profile match {
-    case com.typesafe.slick.driver.oracle.OracleDriver => true
-    case _                                             => false
-  }
+  private lazy val isOracleDriver = profile.getClass.getName.contains("OracleDriver")
 
   abstract override def allPersistenceIdsSource(max: Long): Source[String, NotUsed] = {
     if (isOracleDriver) {


### PR DESCRIPTION
slick-extensions 3.1.0 is a proprietary library (yes, Lightbend has open sourced it, but that doesn't retroactively change the license for existing releases). Technically, any project that includes it on its classpath in production that doesn't have a Lightbend subscription is in breach of the Lightbend license.

This PR solves this problem by removing the binary dependency on the Oracle driver, allowing akka-persistence-jdbc to be used in production without being in violation of Lightbend's license.