### PR TITLE
Update Akka (2.5), Slick (3.2.1) and Hikari (2.6)

### DIFF
--- a/project/ProjectAutoPlugin.scala
+++ b/project/ProjectAutoPlugin.scala
@@ -8,9 +8,9 @@ import sbt._
 import scalariform.formatter.preferences.FormattingPreferences
 
 object ProjectAutoPlugin extends AutoPlugin {
-  final val AkkaVersion = "2.4.18"
-  final val SlickVersion = "3.2.0"
-  final val HikariCPVersion = "2.5.1"
+  final val AkkaVersion = "2.5.3"
+  final val SlickVersion = "3.2.1"
+  final val HikariCPVersion = "2.6.2"
   final val ScalaTestVersion = "3.0.3"
 
   final val formattingPreferences: FormattingPreferences = {
@@ -78,7 +78,7 @@ object ProjectAutoPlugin extends AutoPlugin {
 
    libraryDependencies += "com.typesafe.akka" %% "akka-actor" % AkkaVersion,
    libraryDependencies += "com.typesafe.akka" %% "akka-persistence" % AkkaVersion,
-   libraryDependencies += "com.typesafe.akka" %% "akka-persistence-query-experimental" % AkkaVersion,
+   libraryDependencies += "com.typesafe.akka" %% "akka-persistence-query" % AkkaVersion,
    libraryDependencies += "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
    libraryDependencies += "com.typesafe.slick" %% "slick" % SlickVersion,
    libraryDependencies += "com.typesafe.slick" %% "slick-hikaricp" % SlickVersion,

--- a/src/main/scala/akka/persistence/jdbc/query/javadsl/JdbcReadJournal.scala
+++ b/src/main/scala/akka/persistence/jdbc/query/javadsl/JdbcReadJournal.scala
@@ -18,7 +18,7 @@ package akka.persistence.jdbc.query.javadsl
 
 import akka.NotUsed
 import akka.persistence.jdbc.query.scaladsl.{JdbcReadJournal => ScalaJdbcReadJournal}
-import akka.persistence.query.{EventEnvelope, Offset, EventEnvelope2, javadsl}
+import akka.persistence.query.{EventEnvelope, Offset, javadsl}
 import akka.stream.javadsl.Source
 
 object JdbcReadJournal {
@@ -27,20 +27,18 @@ object JdbcReadJournal {
 
 class JdbcReadJournal(journal: ScalaJdbcReadJournal) extends javadsl.ReadJournal
     with javadsl.CurrentPersistenceIdsQuery
-    with javadsl.AllPersistenceIdsQuery
+    with javadsl.PersistenceIdsQuery
     with javadsl.CurrentEventsByPersistenceIdQuery
     with javadsl.EventsByPersistenceIdQuery
     with javadsl.CurrentEventsByTagQuery
-    with javadsl.CurrentEventsByTagQuery2
-    with javadsl.EventsByTagQuery
-    with javadsl.EventsByTagQuery2 {
+    with javadsl.EventsByTagQuery {
 
   override def currentPersistenceIds(): Source[String, NotUsed] = {
     journal.currentPersistenceIds().asJava
   }
 
-  override def allPersistenceIds(): Source[String, NotUsed] = {
-    journal.allPersistenceIds().asJava
+  override def persistenceIds(): Source[String, NotUsed] = {
+    journal.persistenceIds().asJava
   }
 
   override def currentEventsByPersistenceId(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long): Source[EventEnvelope, NotUsed] = {
@@ -51,19 +49,11 @@ class JdbcReadJournal(journal: ScalaJdbcReadJournal) extends javadsl.ReadJournal
     journal.eventsByPersistenceId(persistenceId, fromSequenceNr, toSequenceNr).asJava
   }
 
-  override def currentEventsByTag(tag: String, offset: Long): Source[EventEnvelope, NotUsed] = {
+  override def currentEventsByTag(tag: String, offset: Offset): Source[EventEnvelope, NotUsed] = {
     journal.currentEventsByTag(tag, offset).asJava
   }
 
-  override def currentEventsByTag(tag: String, offset: Offset): Source[EventEnvelope2, NotUsed] = {
-    journal.currentEventsByTag(tag, offset).asJava
-  }
-
-  override def eventsByTag(tag: String, offset: Long): Source[EventEnvelope, NotUsed] = {
-    journal.eventsByTag(tag, offset).asJava
-  }
-
-  override def eventsByTag(tag: String, offset: Offset): Source[EventEnvelope2, NotUsed] = {
+  override def eventsByTag(tag: String, offset: Offset): Source[EventEnvelope, NotUsed] = {
     journal.eventsByTag(tag, offset).asJava
   }
 }

--- a/src/main/scala/akka/persistence/jdbc/query/package.scala
+++ b/src/main/scala/akka/persistence/jdbc/query/package.scala
@@ -29,12 +29,4 @@ package object query {
       case _                     => throw new IllegalArgumentException("akka-persistence-jdbc does not support " + that.getClass.getName + " offsets")
     }
   }
-
-  def toNewEnvelope(env: EventEnvelope): EventEnvelope2 = env match {
-    case EventEnvelope(offset, persistenceId, sequenceNr, event) =>
-      EventEnvelope2(Sequence(offset), persistenceId, sequenceNr, event)
-  }
-
-  implicit def oldSrcToNewSrc(that: Source[EventEnvelope, NotUsed]): Source[EventEnvelope2, NotUsed] =
-    that.map(toNewEnvelope)
 }

--- a/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByPersistenceIdTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByPersistenceIdTest.scala
@@ -16,7 +16,7 @@
 
 package akka.persistence.jdbc.query
 
-import akka.persistence.query.EventEnvelope
+import akka.persistence.query.{EventEnvelope, Offset, Sequence}
 
 abstract class CurrentEventsByPersistenceIdTest(config: String) extends QueryTestSpec(config) {
 
@@ -39,55 +39,55 @@ abstract class CurrentEventsByPersistenceIdTest(config: String) extends QueryTes
 
       withCurrentEventsByPersistenceId()("my-1", 0, 1) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(1, "my-1", 1, 1))
+        tp.expectNext(EventEnvelope(Offset.sequence(1), "my-1", 1, 1))
         tp.expectComplete()
       }
 
       withCurrentEventsByPersistenceId()("my-1", 1, 1) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(1, "my-1", 1, 1))
+        tp.expectNext(EventEnvelope(Offset.sequence(1), "my-1", 1, 1))
         tp.expectComplete()
       }
 
       withCurrentEventsByPersistenceId()("my-1", 1, 2) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(1, "my-1", 1, 1))
-        tp.expectNext(EventEnvelope(2, "my-1", 2, 2))
+        tp.expectNext(EventEnvelope(Offset.sequence(1), "my-1", 1, 1))
+        tp.expectNext(EventEnvelope(Offset.sequence(2), "my-1", 2, 2))
         tp.expectComplete()
       }
 
       withCurrentEventsByPersistenceId()("my-1", 2, 2) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(2, "my-1", 2, 2))
+        tp.expectNext(EventEnvelope(Offset.sequence(2), "my-1", 2, 2))
         tp.expectComplete()
       }
 
       withCurrentEventsByPersistenceId()("my-1", 2, 3) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(2, "my-1", 2, 2))
-        tp.expectNext(EventEnvelope(3, "my-1", 3, 3))
+        tp.expectNext(EventEnvelope(Offset.sequence(2), "my-1", 2, 2))
+        tp.expectNext(EventEnvelope(Offset.sequence(3), "my-1", 3, 3))
         tp.expectComplete()
       }
 
       withCurrentEventsByPersistenceId()("my-1", 3, 3) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(3, "my-1", 3, 3))
+        tp.expectNext(EventEnvelope(Offset.sequence(3), "my-1", 3, 3))
         tp.expectComplete()
       }
 
       withCurrentEventsByPersistenceId()("my-1", 0, 3) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(1, "my-1", 1, 1))
-        tp.expectNext(EventEnvelope(2, "my-1", 2, 2))
-        tp.expectNext(EventEnvelope(3, "my-1", 3, 3))
+        tp.expectNext(EventEnvelope(Offset.sequence(1), "my-1", 1, 1))
+        tp.expectNext(EventEnvelope(Offset.sequence(2), "my-1", 2, 2))
+        tp.expectNext(EventEnvelope(Offset.sequence(3), "my-1", 3, 3))
         tp.expectComplete()
       }
 
       withCurrentEventsByPersistenceId()("my-1", 1, 3) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(1, "my-1", 1, 1))
-        tp.expectNext(EventEnvelope(2, "my-1", 2, 2))
-        tp.expectNext(EventEnvelope(3, "my-1", 3, 3))
+        tp.expectNext(EventEnvelope(Offset.sequence(1), "my-1", 1, 1))
+        tp.expectNext(EventEnvelope(Offset.sequence(2), "my-1", 2, 2))
+        tp.expectNext(EventEnvelope(Offset.sequence(3), "my-1", 3, 3))
         tp.expectComplete()
       }
     }
@@ -105,26 +105,26 @@ abstract class CurrentEventsByPersistenceIdTest(config: String) extends QueryTes
 
       withCurrentEventsByPersistenceId()("my-1", 1, 1) { tp =>
         tp.request(Int.MaxValue)
-          .expectNext(EventEnvelope(1, "my-1", 1, 1))
+          .expectNext(EventEnvelope(Sequence(1), "my-1", 1, 1))
           .expectComplete()
       }
 
       withCurrentEventsByPersistenceId()("my-1", 2, 2) { tp =>
         tp.request(Int.MaxValue)
-          .expectNext(EventEnvelope(2, "my-1", 2, 2))
+          .expectNext(EventEnvelope(Sequence(2), "my-1", 2, 2))
           .expectComplete()
       }
 
       withCurrentEventsByPersistenceId()("my-1", 3, 3) { tp =>
         tp.request(Int.MaxValue)
-          .expectNext(EventEnvelope(3, "my-1", 3, 3))
+          .expectNext(EventEnvelope(Sequence(3), "my-1", 3, 3))
           .expectComplete()
       }
 
       withCurrentEventsByPersistenceId()("my-1", 2, 3) { tp =>
         tp.request(Int.MaxValue)
-          .expectNext(EventEnvelope(2, "my-1", 2, 2))
-          .expectNext(EventEnvelope(3, "my-1", 3, 3))
+          .expectNext(EventEnvelope(Sequence(2), "my-1", 2, 2))
+          .expectNext(EventEnvelope(Sequence(3), "my-1", 3, 3))
           .expectComplete()
       }
     }

--- a/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByTagTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByTagTest.scala
@@ -16,7 +16,7 @@
 
 package akka.persistence.jdbc.query
 
-import akka.persistence.query.EventEnvelope
+import akka.persistence.query.{EventEnvelope, Offset, Sequence}
 import akka.pattern.ask
 
 abstract class CurrentEventsByTagTest(config: String) extends QueryTestSpec(config) {
@@ -50,30 +50,30 @@ abstract class CurrentEventsByTagTest(config: String) extends QueryTestSpec(conf
 
       withCurrentEventsByTag()("number", 0) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNextPF { case EventEnvelope(1, _, _, _) => }
-        tp.expectNextPF { case EventEnvelope(2, _, _, _) => }
-        tp.expectNextPF { case EventEnvelope(3, _, _, _) => }
+        tp.expectNextPF { case EventEnvelope(Sequence(1), _, _, _) => }
+        tp.expectNextPF { case EventEnvelope(Sequence(2), _, _, _) => }
+        tp.expectNextPF { case EventEnvelope(Sequence(3), _, _, _) => }
         tp.expectComplete()
       }
 
       withCurrentEventsByTag()("number", 1) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNextPF { case EventEnvelope(1, _, _, _) => }
-        tp.expectNextPF { case EventEnvelope(2, _, _, _) => }
-        tp.expectNextPF { case EventEnvelope(3, _, _, _) => }
+        tp.expectNextPF { case EventEnvelope(Sequence(1), _, _, _) => }
+        tp.expectNextPF { case EventEnvelope(Sequence(2), _, _, _) => }
+        tp.expectNextPF { case EventEnvelope(Sequence(3), _, _, _) => }
         tp.expectComplete()
       }
 
       withCurrentEventsByTag()("number", 2) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNextPF { case EventEnvelope(2, _, _, _) => }
-        tp.expectNextPF { case EventEnvelope(3, _, _, _) => }
+        tp.expectNextPF { case EventEnvelope(Sequence(2), _, _, _) => }
+        tp.expectNextPF { case EventEnvelope(Sequence(3), _, _, _) => }
         tp.expectComplete()
       }
 
       withCurrentEventsByTag()("number", 3) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNextPF { case EventEnvelope(3, _, _, _) => }
+        tp.expectNextPF { case EventEnvelope(Sequence(3), _, _, _) => }
         tp.expectComplete()
       }
 
@@ -106,50 +106,50 @@ abstract class CurrentEventsByTagTest(config: String) extends QueryTestSpec(conf
 
       withCurrentEventsByTag()("one", 0) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNextPF { case EventEnvelope(1, _, _, _) => }
+        tp.expectNextPF { case EventEnvelope(Sequence(1), _, _, _) => }
         tp.expectComplete()
       }
 
       withCurrentEventsByTag()("prime", 0) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNextPF { case EventEnvelope(1, _, _, _) => }
-        tp.expectNextPF { case EventEnvelope(2, _, _, _) => }
-        tp.expectNextPF { case EventEnvelope(3, _, _, _) => }
-        tp.expectNextPF { case EventEnvelope(5, _, _, _) => }
-        tp.expectNextPF { case EventEnvelope(6, _, _, _) => }
-        tp.expectNextPF { case EventEnvelope(7, _, _, _) => }
+        tp.expectNextPF { case EventEnvelope(Sequence(1), _, _, _) => }
+        tp.expectNextPF { case EventEnvelope(Sequence(2), _, _, _) => }
+        tp.expectNextPF { case EventEnvelope(Sequence(3), _, _, _) => }
+        tp.expectNextPF { case EventEnvelope(Sequence(5), _, _, _) => }
+        tp.expectNextPF { case EventEnvelope(Sequence(6), _, _, _) => }
+        tp.expectNextPF { case EventEnvelope(Sequence(7), _, _, _) => }
         tp.expectComplete()
       }
 
       withCurrentEventsByTag()("3", 0) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNextPF { case EventEnvelope(3, _, _, _) => }
-        tp.expectNextPF { case EventEnvelope(6, _, _, _) => }
-        tp.expectNextPF { case EventEnvelope(7, _, _, _) => }
+        tp.expectNextPF { case EventEnvelope(Sequence(3), _, _, _) => }
+        tp.expectNextPF { case EventEnvelope(Sequence(6), _, _, _) => }
+        tp.expectNextPF { case EventEnvelope(Sequence(7), _, _, _) => }
         tp.expectComplete()
       }
 
       withCurrentEventsByTag()("4", 0) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNextPF { case EventEnvelope(4, _, _, _) => }
+        tp.expectNextPF { case EventEnvelope(Sequence(4), _, _, _) => }
         tp.expectComplete()
       }
 
       withCurrentEventsByTag()("four", 0) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNextPF { case EventEnvelope(4, _, _, _) => }
+        tp.expectNextPF { case EventEnvelope(Sequence(4), _, _, _) => }
         tp.expectComplete()
       }
 
       withCurrentEventsByTag()("5", 0) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNextPF { case EventEnvelope(5, _, _, _) => }
+        tp.expectNextPF { case EventEnvelope(Sequence(5), _, _, _) => }
         tp.expectComplete()
       }
 
       withCurrentEventsByTag()("five", 0) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNextPF { case EventEnvelope(5, _, _, _) => }
+        tp.expectNextPF { case EventEnvelope(Sequence(5), _, _, _) => }
         tp.expectComplete()
       }
     }

--- a/src/test/scala/akka/persistence/jdbc/query/EventAdapterTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/EventAdapterTest.scala
@@ -16,7 +16,7 @@
 
 package akka.persistence.jdbc.query
 
-import akka.persistence.query.EventEnvelope
+import akka.persistence.query.{EventEnvelope, Offset, Sequence}
 
 import scala.concurrent.duration._
 import akka.pattern.ask
@@ -68,11 +68,11 @@ abstract class EventAdapterTest(config: String) extends QueryTestSpec(config) {
         tp.expectNoMsg(100.millis)
 
         actor1 ! Event("1")
-        tp.expectNext(ExpectNextTimeout, EventEnvelope(1, "my-1", 1, EventRestored("1")))
+        tp.expectNext(ExpectNextTimeout, EventEnvelope(Offset.sequence(1), "my-1", 1, EventRestored("1")))
         tp.expectNoMsg(100.millis)
 
         actor1 ! Event("2")
-        tp.expectNext(ExpectNextTimeout, EventEnvelope(2, "my-1", 2, EventRestored("2")))
+        tp.expectNext(ExpectNextTimeout, EventEnvelope(Offset.sequence(2), "my-1", 2, EventRestored("2")))
         tp.expectNoMsg(100.millis)
         tp.cancel()
       }
@@ -94,12 +94,12 @@ abstract class EventAdapterTest(config: String) extends QueryTestSpec(config) {
       withEventsByTag(10.seconds)("event", 2) { tp =>
 
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(2, "my-2", 1, EventRestored("2")))
-        tp.expectNext(EventEnvelope(3, "my-3", 1, EventRestored("3")))
+        tp.expectNext(EventEnvelope(Offset.sequence(2), "my-2", 1, EventRestored("2")))
+        tp.expectNext(EventEnvelope(Offset.sequence(3), "my-3", 1, EventRestored("3")))
         tp.expectNoMsg(NoMsgTime)
 
         actor1 ! TaggedEvent(Event("1"), "event")
-        tp.expectNext(EventEnvelope(4, "my-1", 2, EventRestored("1")))
+        tp.expectNext(EventEnvelope(Offset.sequence(4), "my-1", 2, EventRestored("1")))
         tp.cancel()
         tp.expectNoMsg(NoMsgTime)
       }
@@ -118,26 +118,26 @@ abstract class EventAdapterTest(config: String) extends QueryTestSpec(config) {
 
       withCurrentEventsByPersistenceId()("my-1", 1, 1) { tp =>
         tp.request(Int.MaxValue)
-          .expectNext(EventEnvelope(1, "my-1", 1, EventRestored("1")))
+          .expectNext(EventEnvelope(Offset.sequence(1), "my-1", 1, EventRestored("1")))
           .expectComplete()
       }
 
       withCurrentEventsByPersistenceId()("my-1", 2, 2) { tp =>
         tp.request(Int.MaxValue)
-          .expectNext(EventEnvelope(2, "my-1", 2, EventRestored("2")))
+          .expectNext(EventEnvelope(Offset.sequence(2), "my-1", 2, EventRestored("2")))
           .expectComplete()
       }
 
       withCurrentEventsByPersistenceId()("my-1", 3, 3) { tp =>
         tp.request(Int.MaxValue)
-          .expectNext(EventEnvelope(3, "my-1", 3, EventRestored("3")))
+          .expectNext(EventEnvelope(Offset.sequence(3), "my-1", 3, EventRestored("3")))
           .expectComplete()
       }
 
       withCurrentEventsByPersistenceId()("my-1", 2, 3) { tp =>
         tp.request(Int.MaxValue)
-          .expectNext(EventEnvelope(2, "my-1", 2, EventRestored("2")))
-          .expectNext(EventEnvelope(3, "my-1", 3, EventRestored("3")))
+          .expectNext(EventEnvelope(Offset.sequence(2), "my-1", 2, EventRestored("2")))
+          .expectNext(EventEnvelope(Offset.sequence(3), "my-1", 3, EventRestored("3")))
           .expectComplete()
       }
     }
@@ -155,30 +155,30 @@ abstract class EventAdapterTest(config: String) extends QueryTestSpec(config) {
 
       withCurrentEventsByTag()("event", 0) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNextPF { case EventEnvelope(1, _, _, EventRestored("1")) => }
-        tp.expectNextPF { case EventEnvelope(2, _, _, EventRestored("2")) => }
-        tp.expectNextPF { case EventEnvelope(3, _, _, EventRestored("3")) => }
+        tp.expectNextPF { case EventEnvelope(Sequence(1), _, _, EventRestored("1")) => }
+        tp.expectNextPF { case EventEnvelope(Sequence(2), _, _, EventRestored("2")) => }
+        tp.expectNextPF { case EventEnvelope(Sequence(3), _, _, EventRestored("3")) => }
         tp.expectComplete()
       }
 
       withCurrentEventsByTag()("event", 1) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNextPF { case EventEnvelope(1, _, _, EventRestored("1")) => }
-        tp.expectNextPF { case EventEnvelope(2, _, _, EventRestored("2")) => }
-        tp.expectNextPF { case EventEnvelope(3, _, _, EventRestored("3")) => }
+        tp.expectNextPF { case EventEnvelope(Sequence(1), _, _, EventRestored("1")) => }
+        tp.expectNextPF { case EventEnvelope(Sequence(2), _, _, EventRestored("2")) => }
+        tp.expectNextPF { case EventEnvelope(Sequence(3), _, _, EventRestored("3")) => }
         tp.expectComplete()
       }
 
       withCurrentEventsByTag()("event", 2) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNextPF { case EventEnvelope(2, _, _, EventRestored("2")) => }
-        tp.expectNextPF { case EventEnvelope(3, _, _, EventRestored("3")) => }
+        tp.expectNextPF { case EventEnvelope(Sequence(2), _, _, EventRestored("2")) => }
+        tp.expectNextPF { case EventEnvelope(Sequence(3), _, _, EventRestored("3")) => }
         tp.expectComplete()
       }
 
       withCurrentEventsByTag()("event", 3) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNextPF { case EventEnvelope(3, _, _, EventRestored("3")) => }
+        tp.expectNextPF { case EventEnvelope(Sequence(3), _, _, EventRestored("3")) => }
         tp.expectComplete()
       }
 

--- a/src/test/scala/akka/persistence/jdbc/query/EventsByPersistenceIdTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/EventsByPersistenceIdTest.scala
@@ -16,7 +16,7 @@
 
 package akka.persistence.jdbc.query
 
-import akka.persistence.query.EventEnvelope
+import akka.persistence.query.{EventEnvelope, Offset}
 
 import scala.concurrent.duration._
 
@@ -50,7 +50,7 @@ abstract class EventsByPersistenceIdTest(config: String) extends QueryTestSpec(c
 
       withEventsByPersistenceId()("my-1", 0, 1) { tp =>
         tp.request(1)
-        tp.expectNext(ExpectNextTimeout, EventEnvelope(1, "my-1", 1, 1))
+        tp.expectNext(ExpectNextTimeout, EventEnvelope(Offset.sequence(1), "my-1", 1, 1))
         tp.request(1)
         tp.expectComplete()
         tp.cancel()
@@ -58,7 +58,7 @@ abstract class EventsByPersistenceIdTest(config: String) extends QueryTestSpec(c
 
       withEventsByPersistenceId()("my-1", 1, 1) { tp =>
         tp.request(1)
-        tp.expectNext(ExpectNextTimeout, EventEnvelope(1, "my-1", 1, 1))
+        tp.expectNext(ExpectNextTimeout, EventEnvelope(Offset.sequence(1), "my-1", 1, 1))
         tp.request(1)
         tp.expectComplete()
         tp.cancel()
@@ -66,9 +66,9 @@ abstract class EventsByPersistenceIdTest(config: String) extends QueryTestSpec(c
 
       withEventsByPersistenceId()("my-1", 1, 2) { tp =>
         tp.request(1)
-        tp.expectNext(ExpectNextTimeout, EventEnvelope(1, "my-1", 1, 1))
+        tp.expectNext(ExpectNextTimeout, EventEnvelope(Offset.sequence(1), "my-1", 1, 1))
         tp.request(1)
-        tp.expectNext(ExpectNextTimeout, EventEnvelope(2, "my-1", 2, 2))
+        tp.expectNext(ExpectNextTimeout, EventEnvelope(Offset.sequence(2), "my-1", 2, 2))
         tp.request(1)
         tp.expectComplete()
         tp.cancel()
@@ -76,7 +76,7 @@ abstract class EventsByPersistenceIdTest(config: String) extends QueryTestSpec(c
 
       withEventsByPersistenceId()("my-1", 2, 2) { tp =>
         tp.request(1)
-        tp.expectNext(ExpectNextTimeout, EventEnvelope(2, "my-1", 2, 2))
+        tp.expectNext(ExpectNextTimeout, EventEnvelope(Offset.sequence(2), "my-1", 2, 2))
         tp.request(1)
         tp.expectComplete()
         tp.cancel()
@@ -84,9 +84,9 @@ abstract class EventsByPersistenceIdTest(config: String) extends QueryTestSpec(c
 
       withEventsByPersistenceId()("my-1", 2, 3) { tp =>
         tp.request(1)
-        tp.expectNext(ExpectNextTimeout, EventEnvelope(2, "my-1", 2, 2))
+        tp.expectNext(ExpectNextTimeout, EventEnvelope(Offset.sequence(2), "my-1", 2, 2))
         tp.request(1)
-        tp.expectNext(ExpectNextTimeout, EventEnvelope(3, "my-1", 3, 3))
+        tp.expectNext(ExpectNextTimeout, EventEnvelope(Offset.sequence(3), "my-1", 3, 3))
         tp.request(1)
         tp.expectComplete()
         tp.cancel()
@@ -94,7 +94,7 @@ abstract class EventsByPersistenceIdTest(config: String) extends QueryTestSpec(c
 
       withEventsByPersistenceId()("my-1", 3, 3) { tp =>
         tp.request(1)
-        tp.expectNext(ExpectNextTimeout, EventEnvelope(3, "my-1", 3, 3))
+        tp.expectNext(ExpectNextTimeout, EventEnvelope(Offset.sequence(3), "my-1", 3, 3))
         tp.request(1)
         tp.expectComplete()
         tp.cancel()
@@ -102,11 +102,11 @@ abstract class EventsByPersistenceIdTest(config: String) extends QueryTestSpec(c
 
       withEventsByPersistenceId()("my-1", 0, 3) { tp =>
         tp.request(1)
-        tp.expectNext(ExpectNextTimeout, EventEnvelope(1, "my-1", 1, 1))
+        tp.expectNext(ExpectNextTimeout, EventEnvelope(Offset.sequence(1), "my-1", 1, 1))
         tp.request(1)
-        tp.expectNext(ExpectNextTimeout, EventEnvelope(2, "my-1", 2, 2))
+        tp.expectNext(ExpectNextTimeout, EventEnvelope(Offset.sequence(2), "my-1", 2, 2))
         tp.request(1)
-        tp.expectNext(ExpectNextTimeout, EventEnvelope(3, "my-1", 3, 3))
+        tp.expectNext(ExpectNextTimeout, EventEnvelope(Offset.sequence(3), "my-1", 3, 3))
         tp.request(1)
         tp.expectComplete()
         tp.cancel()
@@ -114,11 +114,11 @@ abstract class EventsByPersistenceIdTest(config: String) extends QueryTestSpec(c
 
       withEventsByPersistenceId()("my-1", 1, 3) { tp =>
         tp.request(1)
-        tp.expectNext(ExpectNextTimeout, EventEnvelope(1, "my-1", 1, 1))
+        tp.expectNext(ExpectNextTimeout, EventEnvelope(Offset.sequence(1), "my-1", 1, 1))
         tp.request(1)
-        tp.expectNext(ExpectNextTimeout, EventEnvelope(2, "my-1", 2, 2))
+        tp.expectNext(ExpectNextTimeout, EventEnvelope(Offset.sequence(2), "my-1", 2, 2))
         tp.request(1)
-        tp.expectNext(ExpectNextTimeout, EventEnvelope(3, "my-1", 3, 3))
+        tp.expectNext(ExpectNextTimeout, EventEnvelope(Offset.sequence(3), "my-1", 3, 3))
         tp.request(1)
         tp.expectComplete()
         tp.cancel()
@@ -133,11 +133,11 @@ abstract class EventsByPersistenceIdTest(config: String) extends QueryTestSpec(c
         tp.expectNoMsg(100.millis)
 
         actor1 ! 1
-        tp.expectNext(ExpectNextTimeout, EventEnvelope(1, "my-1", 1, 1))
+        tp.expectNext(ExpectNextTimeout, EventEnvelope(Offset.sequence(1), "my-1", 1, 1))
         tp.expectNoMsg(100.millis)
 
         actor1 ! 2
-        tp.expectNext(ExpectNextTimeout, EventEnvelope(2, "my-1", 2, 2))
+        tp.expectNext(ExpectNextTimeout, EventEnvelope(Offset.sequence(2), "my-1", 2, 2))
         tp.expectNoMsg(100.millis)
         tp.cancel()
       }
@@ -151,11 +151,11 @@ abstract class EventsByPersistenceIdTest(config: String) extends QueryTestSpec(c
         tp.expectNoMsg(100.millis)
 
         actor1 ! 1
-        tp.expectNext(ExpectNextTimeout, EventEnvelope(1, "my-1", 1, 1))
+        tp.expectNext(ExpectNextTimeout, EventEnvelope(Offset.sequence(1), "my-1", 1, 1))
         tp.expectNoMsg(100.millis)
 
         actor1 ! 2
-        tp.expectNext(ExpectNextTimeout, EventEnvelope(2, "my-1", 2, 2))
+        tp.expectNext(ExpectNextTimeout, EventEnvelope(Offset.sequence(2), "my-1", 2, 2))
         tp.expectNoMsg(100.millis)
 
         actor2 ! 1
@@ -164,7 +164,7 @@ abstract class EventsByPersistenceIdTest(config: String) extends QueryTestSpec(c
         tp.expectNoMsg(100.millis)
 
         actor1 ! 3
-        tp.expectNext(ExpectNextTimeout, EventEnvelope(3, "my-1", 3, 3))
+        tp.expectNext(ExpectNextTimeout, EventEnvelope(Offset.sequence(3), "my-1", 3, 3))
         tp.expectNoMsg(100.millis)
 
         tp.cancel()
@@ -185,11 +185,11 @@ abstract class EventsByPersistenceIdTest(config: String) extends QueryTestSpec(c
 
       withEventsByPersistenceId()("my-2", 0, Long.MaxValue) { tp =>
         tp.request(1)
-        tp.expectNext(ExpectNextTimeout, EventEnvelope(1, "my-2", 1, 1))
+        tp.expectNext(ExpectNextTimeout, EventEnvelope(Offset.sequence(1), "my-2", 1, 1))
         tp.request(1)
-        tp.expectNext(ExpectNextTimeout, EventEnvelope(2, "my-2", 2, 2))
+        tp.expectNext(ExpectNextTimeout, EventEnvelope(Offset.sequence(2), "my-2", 2, 2))
         tp.request(1)
-        tp.expectNext(ExpectNextTimeout, EventEnvelope(3, "my-2", 3, 3))
+        tp.expectNext(ExpectNextTimeout, EventEnvelope(Offset.sequence(3), "my-2", 3, 3))
         tp.expectNoMsg(100.millis)
 
         actor2 ! 5
@@ -201,9 +201,9 @@ abstract class EventsByPersistenceIdTest(config: String) extends QueryTestSpec(c
         }
 
         tp.request(3)
-        tp.expectNext(ExpectNextTimeout, EventEnvelope(4, "my-2", 4, 5))
-        tp.expectNext(ExpectNextTimeout, EventEnvelope(5, "my-2", 5, 6))
-        tp.expectNext(ExpectNextTimeout, EventEnvelope(6, "my-2", 6, 7))
+        tp.expectNext(ExpectNextTimeout, EventEnvelope(Offset.sequence(4), "my-2", 4, 5))
+        tp.expectNext(ExpectNextTimeout, EventEnvelope(Offset.sequence(5), "my-2", 5, 6))
+        tp.expectNext(ExpectNextTimeout, EventEnvelope(Offset.sequence(6), "my-2", 6, 7))
         tp.expectNoMsg(100.millis)
 
         tp.cancel()

--- a/src/test/scala/akka/persistence/jdbc/query/EventsByTagTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/EventsByTagTest.scala
@@ -16,7 +16,7 @@
 
 package akka.persistence.jdbc.query
 
-import akka.persistence.query.EventEnvelope
+import akka.persistence.query.{EventEnvelope, Offset, Sequence}
 import scala.concurrent.duration._
 import akka.pattern.ask
 
@@ -26,9 +26,9 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config) {
 
   it should "not find events for unknown tags" in {
     withTestActors() { (actor1, actor2, actor3) =>
-      actor1 ! withTags(1, "one")
-      actor2 ! withTags(2, "two")
-      actor3 ! withTags(3, "three")
+      actor1 ! withTags(Offset.sequence(1), "one")
+      actor2 ! withTags(Offset.sequence(2), "two")
+      actor3 ! withTags(Offset.sequence(3), "three")
 
       eventually {
         countJournal.futureValue shouldBe 3
@@ -50,38 +50,38 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config) {
 
       withEventsByTag()("number", Long.MinValue) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(1, "my-1", 1, 1))
-        tp.expectNext(EventEnvelope(2, "my-2", 1, 2))
-        tp.expectNext(EventEnvelope(3, "my-3", 1, 3))
+        tp.expectNext(EventEnvelope(Offset.sequence(1), "my-1", 1, 1))
+        tp.expectNext(EventEnvelope(Offset.sequence(2), "my-2", 1, 2))
+        tp.expectNext(EventEnvelope(Offset.sequence(3), "my-3", 1, 3))
         tp.cancel()
       }
 
       withEventsByTag()("number", 0) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(1, "my-1", 1, 1))
-        tp.expectNext(EventEnvelope(2, "my-2", 1, 2))
-        tp.expectNext(EventEnvelope(3, "my-3", 1, 3))
+        tp.expectNext(EventEnvelope(Offset.sequence(1), "my-1", 1, 1))
+        tp.expectNext(EventEnvelope(Offset.sequence(2), "my-2", 1, 2))
+        tp.expectNext(EventEnvelope(Offset.sequence(3), "my-3", 1, 3))
         tp.cancel()
       }
 
       withEventsByTag()("number", 1) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(1, "my-1", 1, 1))
-        tp.expectNext(EventEnvelope(2, "my-2", 1, 2))
-        tp.expectNext(EventEnvelope(3, "my-3", 1, 3))
+        tp.expectNext(EventEnvelope(Offset.sequence(1), "my-1", 1, 1))
+        tp.expectNext(EventEnvelope(Offset.sequence(2), "my-2", 1, 2))
+        tp.expectNext(EventEnvelope(Offset.sequence(3), "my-3", 1, 3))
         tp.cancel()
       }
 
       withEventsByTag()("number", 2) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(2, "my-2", 1, 2))
-        tp.expectNext(EventEnvelope(3, "my-3", 1, 3))
+        tp.expectNext(EventEnvelope(Offset.sequence(2), "my-2", 1, 2))
+        tp.expectNext(EventEnvelope(Offset.sequence(3), "my-3", 1, 3))
         tp.cancel()
       }
 
       withEventsByTag()("number", 3) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(3, "my-3", 1, 3))
+        tp.expectNext(EventEnvelope(Offset.sequence(3), "my-3", 1, 3))
         tp.cancel()
       }
 
@@ -94,19 +94,19 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config) {
 
       withEventsByTag()("number", 0) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(1, "my-1", 1, 1))
-        tp.expectNext(EventEnvelope(2, "my-2", 1, 2))
-        tp.expectNext(EventEnvelope(3, "my-3", 1, 3))
+        tp.expectNext(EventEnvelope(Offset.sequence(1), "my-1", 1, 1))
+        tp.expectNext(EventEnvelope(Offset.sequence(2), "my-2", 1, 2))
+        tp.expectNext(EventEnvelope(Offset.sequence(3), "my-3", 1, 3))
         tp.expectNoMsg(NoMsgTime)
 
         actor1 ! withTags(1, "number")
-        tp.expectNext(EventEnvelope(4, "my-1", 2, 1))
+        tp.expectNext(EventEnvelope(Offset.sequence(4), "my-1", 2, 1))
 
         actor1 ! withTags(1, "number")
-        tp.expectNext(EventEnvelope(5, "my-1", 3, 1))
+        tp.expectNext(EventEnvelope(Offset.sequence(5), "my-1", 3, 1))
 
         actor1 ! withTags(1, "number")
-        tp.expectNext(EventEnvelope(6, "my-1", 4, 1))
+        tp.expectNext(EventEnvelope(Offset.sequence(6), "my-1", 4, 1))
         tp.cancel()
         tp.expectNoMsg(NoMsgTime)
       }
@@ -125,12 +125,12 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config) {
 
       withEventsByTag()("number", 2) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(2, "my-2", 1, 2))
-        tp.expectNext(EventEnvelope(3, "my-3", 1, 3))
+        tp.expectNext(EventEnvelope(Offset.sequence(2), "my-2", 1, 2))
+        tp.expectNext(EventEnvelope(Offset.sequence(3), "my-3", 1, 3))
         tp.expectNoMsg(NoMsgTime)
 
         actor1 ! withTags(1, "number")
-        tp.expectNext(EventEnvelope(4, "my-1", 2, 1))
+        tp.expectNext(EventEnvelope(Offset.sequence(4), "my-1", 2, 1))
         tp.cancel()
         tp.expectNoMsg(NoMsgTime)
       }
@@ -144,15 +144,15 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config) {
         tp.expectNoMsg(NoMsgTime)
 
         actor1 ! withTags(1, "one") // 1
-        tp.expectNext(EventEnvelope(1, "my-1", 1, 1))
+        tp.expectNext(EventEnvelope(Offset.sequence(1), "my-1", 1, 1))
         tp.expectNoMsg(NoMsgTime)
 
         actor2 ! withTags(1, "one") // 2
-        tp.expectNext(EventEnvelope(2, "my-2", 1, 1))
+        tp.expectNext(EventEnvelope(Offset.sequence(2), "my-2", 1, 1))
         tp.expectNoMsg(NoMsgTime)
 
         actor3 ! withTags(1, "one") // 3
-        tp.expectNext(EventEnvelope(3, "my-3", 1, 1))
+        tp.expectNext(EventEnvelope(Offset.sequence(3), "my-3", 1, 1))
         tp.expectNoMsg(NoMsgTime)
 
         actor1 ! withTags(2, "two") // 4
@@ -165,15 +165,15 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config) {
         tp.expectNoMsg(NoMsgTime)
 
         actor1 ! withTags(1, "one") // 7
-        tp.expectNext(EventEnvelope(7, "my-1", 3, 1))
+        tp.expectNext(EventEnvelope(Offset.sequence(7), "my-1", 3, 1))
         tp.expectNoMsg(NoMsgTime)
 
         actor2 ! withTags(1, "one") // 8
-        tp.expectNext(EventEnvelope(8, "my-2", 3, 1))
+        tp.expectNext(EventEnvelope(Offset.sequence(8), "my-2", 3, 1))
         tp.expectNoMsg(NoMsgTime)
 
         actor3 ! withTags(1, "one") // 9
-        tp.expectNext(EventEnvelope(9, "my-3", 3, 1))
+        tp.expectNext(EventEnvelope(Offset.sequence(9), "my-3", 3, 1))
         tp.expectNoMsg(NoMsgTime)
         tp.cancel()
         tp.expectNoMsg(NoMsgTime)
@@ -203,51 +203,51 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config) {
 
       withEventsByTag(10.seconds)("prime", 0) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(1, "my-1", 1, 1))
-        tp.expectNext(EventEnvelope(2, "my-1", 2, 2))
-        tp.expectNext(EventEnvelope(3, "my-1", 3, 3))
-        tp.expectNext(EventEnvelope(5, "my-1", 5, 5))
-        tp.expectNext(EventEnvelope(6, "my-2", 1, 3))
-        tp.expectNext(EventEnvelope(7, "my-3", 1, 3))
+        tp.expectNext(EventEnvelope(Offset.sequence(1), "my-1", 1, 1))
+        tp.expectNext(EventEnvelope(Offset.sequence(2), "my-1", 2, 2))
+        tp.expectNext(EventEnvelope(Offset.sequence(3), "my-1", 3, 3))
+        tp.expectNext(EventEnvelope(Offset.sequence(5), "my-1", 5, 5))
+        tp.expectNext(EventEnvelope(Offset.sequence(6), "my-2", 1, 3))
+        tp.expectNext(EventEnvelope(Offset.sequence(7), "my-3", 1, 3))
         tp.expectNoMsg(NoMsgTime)
         tp.cancel()
       }
 
       withEventsByTag(10.seconds)("three", 0) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(3, "my-1", 3, 3))
-        tp.expectNext(EventEnvelope(6, "my-2", 1, 3))
-        tp.expectNext(EventEnvelope(7, "my-3", 1, 3))
+        tp.expectNext(EventEnvelope(Offset.sequence(3), "my-1", 3, 3))
+        tp.expectNext(EventEnvelope(Offset.sequence(6), "my-2", 1, 3))
+        tp.expectNext(EventEnvelope(Offset.sequence(7), "my-3", 1, 3))
         tp.expectNoMsg(NoMsgTime)
         tp.cancel()
       }
 
       withEventsByTag(10.seconds)("3", 0) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(3, "my-1", 3, 3))
-        tp.expectNext(EventEnvelope(6, "my-2", 1, 3))
-        tp.expectNext(EventEnvelope(7, "my-3", 1, 3))
+        tp.expectNext(EventEnvelope(Offset.sequence(3), "my-1", 3, 3))
+        tp.expectNext(EventEnvelope(Offset.sequence(6), "my-2", 1, 3))
+        tp.expectNext(EventEnvelope(Offset.sequence(7), "my-3", 1, 3))
         tp.expectNoMsg(NoMsgTime)
         tp.cancel()
       }
 
       withEventsByTag(10.seconds)("one", 0) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(1, "my-1", 1, 1))
+        tp.expectNext(EventEnvelope(Offset.sequence(1), "my-1", 1, 1))
         tp.expectNoMsg(NoMsgTime)
         tp.cancel()
       }
 
       withEventsByTag(10.seconds)("four", 0) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNextPF { case EventEnvelope(4, "my-1", 4, 4) => }
+        tp.expectNextPF { case EventEnvelope(Sequence(4), "my-1", 4, 4) => }
         tp.expectNoMsg(NoMsgTime)
         tp.cancel()
       }
 
       withEventsByTag(10.seconds)("five", 0) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(5, "my-1", 5, 5))
+        tp.expectNext(EventEnvelope(Offset.sequence(5), "my-1", 5, 5))
         tp.expectNoMsg(NoMsgTime)
         tp.cancel()
         tp.expectNoMsg(NoMsgTime)

--- a/src/test/scala/akka/persistence/jdbc/query/QueryTestSpec.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/QueryTestSpec.scala
@@ -24,7 +24,7 @@ import akka.persistence.jdbc.query.EventAdapterTest.{Event, TaggedEvent}
 import akka.persistence.jdbc.query.javadsl.{JdbcReadJournal => JavaJdbcReadJournal}
 import akka.persistence.jdbc.query.scaladsl.JdbcReadJournal
 import akka.persistence.journal.Tagged
-import akka.persistence.query.{EventEnvelope, PersistenceQuery}
+import akka.persistence.query.{EventEnvelope, Offset, PersistenceQuery}
 import akka.stream.Materializer
 import akka.stream.scaladsl.Sink
 import akka.stream.testkit.TestSubscriber
@@ -60,7 +60,7 @@ trait ScalaJdbcReadJournalOperations extends ReadJournalOperations {
   }
 
   def withAllPersistenceIds(within: FiniteDuration)(f: TestSubscriber.Probe[String] => Unit): Unit = {
-    val tp = readJournal.allPersistenceIds().runWith(TestSink.probe[String])
+    val tp = readJournal.persistenceIds().runWith(TestSink.probe[String])
     tp.within(within)(f(tp))
   }
 
@@ -75,12 +75,12 @@ trait ScalaJdbcReadJournalOperations extends ReadJournalOperations {
   }
 
   def withCurrentEventsByTag(within: FiniteDuration)(tag: String, offset: Long)(f: TestSubscriber.Probe[EventEnvelope] => Unit): Unit = {
-    val tp = readJournal.currentEventsByTag(tag, offset).runWith(TestSink.probe[EventEnvelope])
+    val tp = readJournal.currentEventsByTag(tag, Offset.sequence(offset)).runWith(TestSink.probe[EventEnvelope])
     tp.within(within)(f(tp))
   }
 
   def withEventsByTag(within: FiniteDuration)(tag: String, offset: Long)(f: TestSubscriber.Probe[EventEnvelope] => Unit): Unit = {
-    val tp = readJournal.eventsByTag(tag, offset).runWith(TestSink.probe[EventEnvelope])
+    val tp = readJournal.eventsByTag(tag, Offset.sequence(offset)).runWith(TestSink.probe[EventEnvelope])
     tp.within(within)(f(tp))
   }
 
@@ -107,7 +107,7 @@ trait JavaDslJdbcReadJournalOperations extends ReadJournalOperations {
   }
 
   def withAllPersistenceIds(within: FiniteDuration = 1.second)(f: TestSubscriber.Probe[String] => Unit): Unit = {
-    val tp = readJournal.allPersistenceIds().runWith(JavaSink.probe(system), mat)
+    val tp = readJournal.persistenceIds().runWith(JavaSink.probe(system), mat)
     tp.within(within)(f(tp))
   }
 
@@ -122,12 +122,12 @@ trait JavaDslJdbcReadJournalOperations extends ReadJournalOperations {
   }
 
   def withCurrentEventsByTag(within: FiniteDuration = 1.second)(tag: String, offset: Long)(f: TestSubscriber.Probe[EventEnvelope] => Unit): Unit = {
-    val tp = readJournal.currentEventsByTag(tag, offset).runWith(JavaSink.probe(system), mat)
+    val tp = readJournal.currentEventsByTag(tag, Offset.sequence(offset)).runWith(JavaSink.probe(system), mat)
     tp.within(within)(f(tp))
   }
 
   def withEventsByTag(within: FiniteDuration = 1.second)(tag: String, offset: Long)(f: TestSubscriber.Probe[EventEnvelope] => Unit): Unit = {
-    val tp = readJournal.eventsByTag(tag, offset).runWith(JavaSink.probe(system), mat)
+    val tp = readJournal.eventsByTag(tag, Offset.sequence(offset)).runWith(JavaSink.probe(system), mat)
     tp.within(within)(f(tp))
   }
 


### PR DESCRIPTION
  * Update Akka to 2.5(.3). Akka 2.5 drops the old persistence APIs and
    finalizes on the new interfaces. Akka maintains binary compatibility, so
    this should be compatible with all 2.5.x releases.
  * Update Slick to 3.2.1, which is *not* binary compatible with Slick 3.2
  * Update HikariCP version to 2.6. This should be transparent.