### PR TITLE
Event by tag bug

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -154,6 +154,21 @@ jdbc-read-journal {
 
   dao = "akka.persistence.jdbc.query.dao.ByteArrayReadJournalDao"
 
+  # Settings for determining if ids (ordering column) in the journal are out of sequence.
+  journal-sequence-retrieval {
+    # The maximum number of ids that will be retrieved in each batch
+    batch-size = 10000
+    # In case a number in the sequence is missing, this is the ammount of retries that will be done to see
+    # if the number is still found. Note that the time after which a number in the sequence is assumed missing is
+    # equal to maxTries * queryDelay
+    # (maxTries may not be zero)
+    max-tries = 10
+    # How often the actor will query for new data
+    query-delay = 1 second
+    # The maximum backoff time before trying to query again in case of database failures
+    max-backoff-query-delay = 1 minute
+  }
+
   tables {
     journal {
       tableName = "journal"

--- a/src/main/scala/akka/persistence/jdbc/config/AkkaPersistenceConfig.scala
+++ b/src/main/scala/akka/persistence/jdbc/config/AkkaPersistenceConfig.scala
@@ -99,9 +99,20 @@ class SnapshotConfig(config: Config) {
   override def toString: String = s"SnapshotConfig($slickConfiguration,$snapshotTableConfiguration,$pluginConfig)"
 }
 
+object JournalSequenceRetrievalConfig {
+  def apply(config: Config): JournalSequenceRetrievalConfig = JournalSequenceRetrievalConfig(
+    batchSize = config.asInt("journal-sequence-retrieval.batch-size", 10000),
+    maxTries = config.asInt("journal-sequence-retrieval.max-tries", 10),
+    queryDelay = config.asFiniteDuration("journal-sequence-retrieval.query-delay", 1.second),
+    maxBackoffQueryDelay = config.asFiniteDuration("journal-sequence-retrieval.max-backoff-query-delay", 1.minute)
+  )
+}
+case class JournalSequenceRetrievalConfig(batchSize: Int, maxTries: Int, queryDelay: FiniteDuration, maxBackoffQueryDelay: FiniteDuration)
+
 class ReadJournalConfig(config: Config) {
   val slickConfiguration = new SlickConfiguration(config)
   val journalTableConfiguration = new JournalTableConfiguration(config)
+  val journalSequenceRetrievalConfiguration = JournalSequenceRetrievalConfig(config)
   val pluginConfig = new ReadJournalPluginConfig(config)
   val refreshInterval: FiniteDuration = config.asFiniteDuration("refresh-interval", 1.second)
   val maxBufferSize: Int = config.as[String]("max-buffer-size", "500").toInt

--- a/src/main/scala/akka/persistence/jdbc/query/JournalSequenceActor.scala
+++ b/src/main/scala/akka/persistence/jdbc/query/JournalSequenceActor.scala
@@ -1,0 +1,114 @@
+package akka.persistence.jdbc.query
+
+import akka.actor.{Actor, ActorLogging, Cancellable, Props, Status}
+import akka.persistence.jdbc.query.dao.ReadJournalDao
+import akka.pattern.pipe
+import akka.persistence.jdbc.config.JournalSequenceRetrievalConfig
+import akka.stream.Materializer
+import akka.stream.scaladsl.Sink
+
+import scala.concurrent.duration.FiniteDuration
+
+object JournalSequenceActor {
+  def props(readJournalDao: ReadJournalDao, config: JournalSequenceRetrievalConfig)(implicit materializer: Materializer): Props = Props(new JournalSequenceActor(readJournalDao, config))
+
+  private case object QueryOrderingIds
+  private case class NewOrderingIds(elements: Seq[OrderingId])
+
+  private case class AssumeMaxOrderingId(max: OrderingId)
+
+  case object GetMaxOrderingId
+  case class MaxOrderingId(maxOrdering: OrderingId)
+
+  private type OrderingId = Long
+}
+
+/**
+ * To support the EventsByTag query, this actor keeps track of which rows are visible in the database.
+ * This is required to guarantee the EventByTag does not skip any rows in case rows with a higher (ordering) id are
+ * visible in the database before rows with a lower (ordering) id.
+ */
+class JournalSequenceActor(readJournalDao: ReadJournalDao, config: JournalSequenceRetrievalConfig)(implicit materializer: Materializer) extends Actor with ActorLogging {
+  import JournalSequenceActor._
+  import context.dispatcher
+  import config.{maxTries, maxBackoffQueryDelay, queryDelay, batchSize}
+
+  override def receive: Receive = receive(0L, Map.empty, 0)
+
+  override def preStart(): Unit = {
+    self ! QueryOrderingIds
+    val scheduler = context.system.scheduler
+    readJournalDao.maxJournalSequence().mapTo[Long].onComplete {
+      case scala.util.Success(maxInDatabase) =>
+        // All elements smaller than max can be assumed missing after this delay
+        val delay = queryDelay * maxTries
+        scheduler.scheduleOnce(delay, self, AssumeMaxOrderingId(maxInDatabase))
+      case scala.util.Failure(t) =>
+        log.info("Failed to recover fast, using event-by-event recovery instead. Cause: {}", t)
+    }
+  }
+
+  /**
+   * @param currentMaxOrdering The highest ordering value for which it is known that no missing elements exist
+   * @param missingByCounter A map with missing orderingIds. The key of the map is the count at which the missing elements
+   *                         can be assumed to be "skipped ids" (they are no longer assumed missing).
+   * @param moduloCounter A counter which is incremented every time a new query have been executed, modulo `maxTries`
+   * @param previousDelay The last used delay (may change in case failures occur)
+   */
+  def receive(currentMaxOrdering: OrderingId, missingByCounter: Map[Int, Set[OrderingId]], moduloCounter: Int, previousDelay: FiniteDuration = queryDelay): Receive = {
+    case AssumeMaxOrderingId(max) =>
+      if (currentMaxOrdering < max) {
+        context.become(receive(max, missingByCounter, moduloCounter, previousDelay))
+      }
+    case GetMaxOrderingId =>
+      sender() ! MaxOrderingId(currentMaxOrdering)
+    case QueryOrderingIds =>
+      readJournalDao.journalSequence(currentMaxOrdering, batchSize).runWith(Sink.seq)
+        .map(result => NewOrderingIds(result)) pipeTo self
+    case NewOrderingIds(elements) =>
+      val givenUp = missingByCounter.getOrElse(moduloCounter, Set.empty)
+      val (nextmax, _, missingElems) = elements.foldLeft[(OrderingId, OrderingId, Set[OrderingId])](currentMaxOrdering, currentMaxOrdering, Set.empty) {
+        case ((currentMax, previousElement, missing), elem) =>
+          val newMissing = if (previousElement + 1 < elem && !givenUp(elem)) {
+            val currentlyMissing = previousElement + 1 until elem
+            def alreadyMissing(e: Long) = missingByCounter.values.exists(_.contains(e))
+            missing ++ currentlyMissing.filterNot(alreadyMissing)
+          } else missing
+          val newMax =
+            if (currentMax + 1 == elem) elem
+            else if ((currentMax + 1).until(elem).forall(givenUp.contains)) elem
+            else currentMax
+          (newMax, elem, newMissing)
+      }
+      val newMissingByCounter = (missingByCounter + (moduloCounter -> missingElems)).map {
+        case (key, value) =>
+          key -> value.filter(missingId => missingId > nextmax)
+      }
+      if (nextmax - currentMaxOrdering >= batchSize && newMissingByCounter.values.forall(_.isEmpty)) {
+        // Many elements have been retrieved but none are missing
+        // We can query again immediately, as this allows the actor to rapidly retrieve the real max ordering
+        self ! QueryOrderingIds
+        context.become(receive(nextmax, newMissingByCounter, moduloCounter))
+      } else {
+        scheduleQuery(queryDelay)
+        context.become(receive(nextmax, newMissingByCounter, (moduloCounter + 1) % maxTries))
+      }
+    case Status.Failure(t) =>
+      val newDelay = maxBackoffQueryDelay.min(previousDelay * 2)
+      if (newDelay == maxBackoffQueryDelay) {
+        log.warning("Failed to query max ordering id because of {}, retrying in {}", t, newDelay)
+      }
+      scheduleQuery(newDelay)
+      context.become(receive(currentMaxOrdering, missingByCounter, moduloCounter, newDelay))
+  }
+
+  var lastScheduledEvent: Option[Cancellable] = None
+
+  def scheduleQuery(delay: FiniteDuration): Unit = {
+    lastScheduledEvent = Some(context.system.scheduler.scheduleOnce(delay, self, QueryOrderingIds))
+  }
+
+  override def postStop(): Unit = {
+    lastScheduledEvent.foreach(_.cancel())
+  }
+}

--- a/src/main/scala/akka/persistence/jdbc/query/dao/ReadJournalDao.scala
+++ b/src/main/scala/akka/persistence/jdbc/query/dao/ReadJournalDao.scala
@@ -22,6 +22,7 @@ import akka.persistence.PersistentRepr
 import akka.stream.scaladsl.Source
 
 import scala.collection.immutable._
+import scala.concurrent.Future
 import scala.util.Try
 
 trait ReadJournalDao {
@@ -34,10 +35,22 @@ trait ReadJournalDao {
    * Returns a Source of bytes for certain tag from an offset. The result is sorted by
    * created time asc thus the offset is relative to the creation time
    */
-  def eventsByTag(tag: String, offset: Long, max: Long): Source[Try[(PersistentRepr, Set[String], JournalRow)], NotUsed]
+  def eventsByTag(tag: String, offset: Long, maxOffset: Long, max: Long): Source[Try[(PersistentRepr, Set[String], JournalRow)], NotUsed]
 
   /**
    * Returns a Source of bytes for a certain persistenceId
    */
   def messages(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long): Source[Try[PersistentRepr], NotUsed]
+
+  /**
+   * @param offset Minimum value to retrieve
+   * @param limit Maximum number of values to retrieve
+   * @return A Source of journal event sequence numbers (corresponding to the Ordering column)
+   */
+  def journalSequence(offset: Long, limit: Long): Source[Long, NotUsed]
+
+  /**
+   * @return The value of the maximum (ordering) id in the journal
+   */
+  def maxJournalSequence(): Future[Long]
 }

--- a/src/main/scala/akka/persistence/jdbc/query/scaladsl/JdbcReadJournal.scala
+++ b/src/main/scala/akka/persistence/jdbc/query/scaladsl/JdbcReadJournal.scala
@@ -21,6 +21,7 @@ import akka.NotUsed
 import akka.actor.ExtendedActorSystem
 import akka.persistence.jdbc.JournalRow
 import akka.persistence.jdbc.config.ReadJournalConfig
+import akka.persistence.jdbc.query.JournalSequenceActor.{GetMaxOrderingId, MaxOrderingId}
 import akka.persistence.jdbc.query.dao.ReadJournalDao
 import akka.persistence.jdbc.util.{SlickDatabase, SlickDriver}
 import akka.persistence.query.scaladsl._
@@ -29,6 +30,7 @@ import akka.persistence.{Persistence, PersistentRepr}
 import akka.serialization.{Serialization, SerializationExtension}
 import akka.stream.scaladsl.{Sink, Source}
 import akka.stream.{ActorMaterializer, Materializer}
+import akka.util.Timeout
 import com.typesafe.config.Config
 import slick.jdbc.JdbcBackend._
 import slick.jdbc.JdbcProfile
@@ -78,6 +80,8 @@ class JdbcReadJournal(config: Config)(implicit val system: ExtendedActorSystem) 
     }
   }
 
+  // Started lazily to prevent the actor for querying the db if no eventsByTag queries are used
+  private[query] lazy val orderingActor = system.actorOf(JournalSequenceActor.props(readJournalDao, readJournalConfig.journalSequenceRetrievalConfiguration))
   private val delaySource =
     Source.tick(readJournalConfig.refreshInterval, 0.seconds, 0).take(1)
 
@@ -134,7 +138,13 @@ class JdbcReadJournal(config: Config)(implicit val system: ExtendedActorSystem) 
     currentEventsByTag(tag, offset.value)
 
   private def currentJournalEventsByTag(tag: String, offset: Long, max: Long): Source[(PersistentRepr, Set[String], JournalRow), NotUsed] = {
-    readJournalDao.eventsByTag(tag, offset, max)
+    import akka.pattern.ask
+    implicit val askTimeout = Timeout(100.millis)
+    Source.fromFuture(orderingActor.ask(GetMaxOrderingId).mapTo[MaxOrderingId])
+      .flatMapConcat { latestOrdering =>
+        if (latestOrdering.maxOrdering < offset) Source.empty
+        else readJournalDao.eventsByTag(tag, offset, latestOrdering.maxOrdering, max)
+      }
       .mapAsync(1)(Future.fromTry)
   }
 

--- a/src/main/scala/akka/persistence/jdbc/util/ConfigOps.scala
+++ b/src/main/scala/akka/persistence/jdbc/util/ConfigOps.scala
@@ -38,6 +38,10 @@ object ConfigOps {
       Try(config.getConfig(key))
         .getOrElse(default)
 
+    def asInt(key: String, default: Int): Int =
+      Try(config.getInt(key))
+        .getOrElse(default)
+
     def asBoolean(key: String, default: Boolean) =
       Try(config.getBoolean(key))
         .getOrElse(default)

--- a/src/test/resources/h2-application.conf
+++ b/src/test/resources/h2-application.conf
@@ -45,7 +45,7 @@ jdbc-snapshot-store {
 
 # the akka-persistence-query provider in use
 jdbc-read-journal {
-  refresh-interval = "100ms"
+  refresh-interval = "10ms"
 
   max-buffer-size = "500"
 

--- a/src/test/resources/mysql-application.conf
+++ b/src/test/resources/mysql-application.conf
@@ -47,7 +47,7 @@ jdbc-snapshot-store {
 
 # the akka-persistence-query provider in use
 jdbc-read-journal {
-  refresh-interval = "100ms"
+  refresh-interval = "10ms"
 
   max-buffer-size = "250"
 

--- a/src/test/resources/oracle-application.conf
+++ b/src/test/resources/oracle-application.conf
@@ -61,7 +61,7 @@ jdbc-snapshot-store {
 # the akka-persistence-query provider in use
 jdbc-read-journal {
 
-  refresh-interval = "100ms"
+  refresh-interval = "10ms"
 
   max-buffer-size = "500"
 

--- a/src/test/resources/postgres-application.conf
+++ b/src/test/resources/postgres-application.conf
@@ -48,7 +48,7 @@ jdbc-snapshot-store {
 
 # the akka-persistence-query provider in use
 jdbc-read-journal {
-  refresh-interval = "100ms"
+  refresh-interval = "10ms"
 
   max-buffer-size = "500"
 

--- a/src/test/resources/schema/h2/h2-schema.sql
+++ b/src/test/resources/schema/h2/h2-schema.sql
@@ -10,6 +10,8 @@ CREATE TABLE IF NOT EXISTS PUBLIC.journal (
   PRIMARY KEY(persistence_id, sequence_number)
 );
 
+CREATE UNIQUE INDEX journal_ordering_idx ON PUBLIC.journal(ordering);
+
 DROP TABLE IF EXISTS PUBLIC.snapshot;
 
 CREATE TABLE IF NOT EXISTS PUBLIC.snapshot (

--- a/src/test/resources/schema/mysql/mysql-schema.sql
+++ b/src/test/resources/schema/mysql/mysql-schema.sql
@@ -10,6 +10,8 @@ CREATE TABLE IF NOT EXISTS journal (
   PRIMARY KEY(persistence_id, sequence_number)
 );
 
+CREATE UNIQUE INDEX journal_ordering_idx ON journal(ordering);
+
 DROP TABLE IF EXISTS snapshot;
 
 CREATE TABLE IF NOT EXISTS snapshot (

--- a/src/test/resources/schema/oracle/oracle-schema.sql
+++ b/src/test/resources/schema/oracle/oracle-schema.sql
@@ -12,6 +12,9 @@ CREATE TABLE "journal" (
 )
 /
 
+CREATE UNIQUE INDEX "journal_ordering_idx" ON "journal"("ordering")
+/
+
 CREATE OR REPLACE TRIGGER "ordering_seq_trigger"
 BEFORE INSERT ON "journal"
 FOR EACH ROW

--- a/src/test/resources/schema/postgres/postgres-schema.sql
+++ b/src/test/resources/schema/postgres/postgres-schema.sql
@@ -10,6 +10,8 @@ CREATE TABLE IF NOT EXISTS public.journal (
   PRIMARY KEY(persistence_id, sequence_number)
 );
 
+CREATE UNIQUE INDEX journal_ordering_idx ON public.journal(ordering);
+
 DROP TABLE IF EXISTS public.snapshot;
 
 CREATE TABLE IF NOT EXISTS public.snapshot (
@@ -19,3 +21,4 @@ CREATE TABLE IF NOT EXISTS public.snapshot (
   snapshot BYTEA NOT NULL,
   PRIMARY KEY(persistence_id, sequence_number)
 );
+

--- a/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByTagTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByTagTest.scala
@@ -19,7 +19,7 @@ package akka.persistence.jdbc.query
 import akka.persistence.query.EventEnvelope
 import akka.pattern.ask
 
-abstract class CurrentEventsByTagTest(config: String) extends QueryTestSpec(config) {
+abstract class CurrentEventsByTagTest(config: String) extends QueryTestSpec(config) with ScalaJdbcReadJournalOperations {
 
   it should "not find an event by tag for unknown tag" in {
     withTestActors() { (actor1, actor2, actor3) =>
@@ -29,6 +29,9 @@ abstract class CurrentEventsByTagTest(config: String) extends QueryTestSpec(conf
 
       eventually {
         countJournal.futureValue shouldBe 3
+      }
+      eventually {
+        latestOrdering.futureValue shouldBe 3
       }
 
       withCurrentEventsByTag()("unknown", 0) { tp =>
@@ -46,6 +49,10 @@ abstract class CurrentEventsByTagTest(config: String) extends QueryTestSpec(conf
 
       eventually {
         countJournal.futureValue shouldBe 3
+      }
+
+      eventually {
+        latestOrdering.futureValue shouldBe 3
       }
 
       withCurrentEventsByTag()("number", 0) { tp =>
@@ -102,6 +109,9 @@ abstract class CurrentEventsByTagTest(config: String) extends QueryTestSpec(conf
         eventually {
           countJournal.futureValue shouldBe 9
         }
+        eventually {
+          latestOrdering.futureValue shouldBe 9
+        }
       }
 
       withCurrentEventsByTag()("one", 0) { tp =>
@@ -155,10 +165,10 @@ abstract class CurrentEventsByTagTest(config: String) extends QueryTestSpec(conf
     }
 }
 
-class PostgresScalaCurrentEventsByTagTest extends CurrentEventsByTagTest("postgres-application.conf") with ScalaJdbcReadJournalOperations with PostgresCleaner
+class PostgresScalaCurrentEventsByTagTest extends CurrentEventsByTagTest("postgres-application.conf") with PostgresCleaner
 
-class MySQLScalaCurrentEventsByTagTest extends CurrentEventsByTagTest("mysql-application.conf") with ScalaJdbcReadJournalOperations with MysqlCleaner
+class MySQLScalaCurrentEventsByTagTest extends CurrentEventsByTagTest("mysql-application.conf") with MysqlCleaner
 
-class OracleScalaCurrentEventsByTagTest extends CurrentEventsByTagTest("oracle-application.conf") with ScalaJdbcReadJournalOperations with OracleCleaner
+class OracleScalaCurrentEventsByTagTest extends CurrentEventsByTagTest("oracle-application.conf") with OracleCleaner
 
-class H2ScalaCurrentEventsByTagTest extends CurrentEventsByTagTest("h2-application.conf") with ScalaJdbcReadJournalOperations with H2Cleaner
+class H2ScalaCurrentEventsByTagTest extends CurrentEventsByTagTest("h2-application.conf") with H2Cleaner

--- a/src/test/scala/akka/persistence/jdbc/query/JournalSequenceActorTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/JournalSequenceActorTest.scala
@@ -1,0 +1,214 @@
+package akka.persistence.jdbc.query
+
+import akka.actor.ActorRef
+import akka.pattern.ask
+import akka.persistence.jdbc.config.JournalSequenceRetrievalConfig
+import akka.persistence.jdbc.{JournalRow, MaterializerSpec, SimpleSpec}
+import akka.persistence.jdbc.journal.dao.JournalTables
+import akka.persistence.jdbc.query.JournalSequenceActor.{GetMaxOrderingId, MaxOrderingId}
+import akka.persistence.jdbc.query.dao.TestProbeReadJournalDao
+import akka.persistence.jdbc.util.SlickDriver
+import akka.stream.scaladsl.{Sink, Source}
+import akka.testkit.TestProbe
+import slick.jdbc.JdbcProfile
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+abstract class JournalSequenceActorTest(configFile: String, isOracle: Boolean) extends QueryTestSpec(configFile) with ScalaJdbcReadJournalOperations with JournalTables {
+
+  val journalSequenceActorConfig = readJournal.readJournalConfig.journalSequenceRetrievalConfiguration
+  val profile: JdbcProfile = SlickDriver.forDriverName(config)
+  val journalTableCfg = journalConfig.journalTableConfiguration
+
+  import profile.api._
+
+  implicit val askTimeout = 50.millis
+
+  def generateId: Int = 0
+
+  behavior of "JournalSequenceActor"
+
+  it should "recover normally" in {
+    val numberOfRows = 15000
+    val rows = for (i <- 1 to numberOfRows) yield JournalRow(generateId, deleted = false, "id", i, Array(0.toByte))
+    db.run(JournalTable ++= rows).futureValue
+    withJournalSequenceActor(maxTries = 100) { actor =>
+      eventually {
+        actor.ask(GetMaxOrderingId).mapTo[MaxOrderingId].futureValue shouldBe MaxOrderingId(numberOfRows)
+      }
+    }
+  }
+
+  it should s"recover ${if (isOracle) "one hundred thousand" else "one million"} events quickly if no ids are missing" in {
+    val elements = if (isOracle) 100000 else 1000000
+    Source.fromIterator(() => (1 to elements).iterator)
+      .map(id => JournalRow(id, deleted = false, "id", id, Array(0.toByte)))
+      .grouped(10000)
+      .mapAsync(4) { rows =>
+        db.run(JournalTable.forceInsertAll(rows))
+      }
+      .runWith(Sink.ignore).futureValue
+
+    val startTime = System.currentTimeMillis()
+    withJournalSequenceActor(maxTries = 100) { actor =>
+      val patienceConfig = PatienceConfig(10.seconds)
+      eventually {
+        val currentMax = actor.ask(GetMaxOrderingId).mapTo[MaxOrderingId].futureValue.maxOrdering
+        currentMax shouldBe elements
+      }(patienceConfig, implicitly)
+    }
+    val timeTaken = System.currentTimeMillis() - startTime
+    log.info(s"Recovered all events in $timeTaken ms")
+  }
+
+  it should s"assume that the max ordering id in the database on startup is the max after (queryDelay * maxTries)" in {
+    val maxElement = 100000
+    // only even numbers, odd numbers are missing
+    val idSeq = 2 to maxElement by 2
+    Source.fromIterator(() => idSeq.iterator)
+      .map(id => JournalRow(id, deleted = false, "id", id, Array(0.toByte)))
+      .grouped(10000)
+      .mapAsync(4) { rows =>
+        db.run(JournalTable.forceInsertAll(rows))
+      }
+      .runWith(Sink.ignore).futureValue
+
+    val highestValue = if (isOracle) {
+      // ForceInsert does not seem to work for oracle, we must delete the odd numbered events
+      db.run(JournalTable.filter(_.ordering % 2L === 1L).delete).futureValue
+      maxElement / 2
+    } else maxElement
+
+    withJournalSequenceActor(maxTries = 2) { actor =>
+      // The actor should assume the max after 2 seconds
+      val patienceConfig = PatienceConfig(3.seconds)
+      eventually {
+        val currentMax = actor.ask(GetMaxOrderingId).mapTo[MaxOrderingId].futureValue.maxOrdering
+        currentMax shouldBe highestValue
+      }(patienceConfig, implicitly)
+    }
+  }
+
+  override def afterAll(): Unit = {
+    system.terminate()
+    super.afterAll()
+  }
+
+  /**
+   * @param maxTries The number of tries before events are assumed missing
+   *                 (since the actor queries every second by default,
+   *                 this is effectively the number of seconds after which events are assumed missing)
+   */
+  def withJournalSequenceActor(maxTries: Int)(f: ActorRef => Unit): Unit = {
+    val actor = system.actorOf(JournalSequenceActor.props(readJournal.readJournalDao, journalSequenceActorConfig.copy(maxTries = maxTries)))
+    try f(actor) finally system.stop(actor)
+  }
+
+}
+
+class MockDaoJournalSequenceActorTest extends SimpleSpec with MaterializerSpec {
+
+  def fetchMaxOrderingId(journalSequenceActor: ActorRef): Future[Long] = {
+    import system.dispatcher
+    journalSequenceActor.ask(GetMaxOrderingId)(20.millis).mapTo[MaxOrderingId].map(_.maxOrdering)
+  }
+
+  it should "re-query with delay only when events are missing." in {
+    val batchSize = 100
+    val maxTries = 5
+    val queryDelay = 200.millis
+
+    val almostQueryDelay = queryDelay - 50.millis
+    val almostImmediately = 50.millis
+    withTestProbeJournalSequenceActor(batchSize, maxTries, queryDelay) { (daoProbe, actor) =>
+      daoProbe.expectMsg(almostImmediately, TestProbeReadJournalDao.JournalSequence(0, batchSize))
+      val firstBatch = (1L to 40L) ++ (51L to 110L)
+      daoProbe.reply(firstBatch)
+      withClue(s"when events are missing, the actor should wait for $queryDelay before querying again") {
+        daoProbe.expectNoMsg(almostQueryDelay)
+        daoProbe.expectMsg(almostQueryDelay, TestProbeReadJournalDao.JournalSequence(40, batchSize))
+      }
+      // number 41 is still missing after this batch
+      val secondBatch = 42L to 110L
+      daoProbe.reply(secondBatch)
+      withClue(s"when events are missing, the actor should wait for $queryDelay before querying again") {
+        daoProbe.expectNoMsg(almostQueryDelay)
+        daoProbe.expectMsg(almostQueryDelay, TestProbeReadJournalDao.JournalSequence(40, batchSize))
+      }
+      val thirdBatch = 41L to 110L
+      daoProbe.reply(thirdBatch)
+      withClue(s"when no more events are missing, but less that batchSize elemens have been received, " +
+        s"the actor should wait for $queryDelay before querying again") {
+        daoProbe.expectNoMsg(almostQueryDelay)
+        daoProbe.expectMsg(almostQueryDelay, TestProbeReadJournalDao.JournalSequence(110, batchSize))
+      }
+
+      val fourthBatch = 111L to 210L
+      daoProbe.reply(fourthBatch)
+      withClue("When no more events are missing and the number of events received is equal to batchSize, " +
+        "the actor should query again immediately") {
+        daoProbe.expectMsg(almostImmediately, TestProbeReadJournalDao.JournalSequence(210, batchSize))
+      }
+
+      // Reply to prevent a dead letter warning on the timeout
+      daoProbe.reply(Seq.empty)
+    }
+  }
+
+  it should "Assume an element missing after the configured amount of maxTries" in {
+    val batchSize = 100
+    val maxTries = 5
+    val queryDelay = 150.millis
+
+    val slightlyMoreThanQueryDelay = queryDelay + 50.millis
+    val almostImmediately = 20.millis
+
+    val allIds = (1L to 40L) ++ (43L to 200L)
+
+    withTestProbeJournalSequenceActor(batchSize, maxTries, queryDelay) { (daoProbe, actor) =>
+      daoProbe.expectMsg(almostImmediately, TestProbeReadJournalDao.JournalSequence(0, batchSize))
+      daoProbe.reply(allIds.take(100))
+
+      val idsLargerThan40 = allIds.dropWhile(_ <= 40)
+      val retryResponse = idsLargerThan40.take(100)
+      for (i <- 1 to maxTries) withClue(s"should retry $maxTries times (attempt $i)") {
+        daoProbe.expectMsg(slightlyMoreThanQueryDelay, TestProbeReadJournalDao.JournalSequence(40, batchSize))
+        daoProbe.reply(retryResponse)
+      }
+
+      // sanity check
+      retryResponse.last shouldBe 142
+      withClue("The elements 41 and 42 should be assumed missing") {
+        fetchMaxOrderingId(actor).futureValue shouldBe 142
+      }
+      withClue("Since a full batch has been receive the actor should query again immediately") {
+        daoProbe.expectMsg(almostImmediately, TestProbeReadJournalDao.JournalSequence(142, batchSize))
+      }
+
+      // Reply to prevent a dead letter warning on the timeout
+      daoProbe.reply(Seq.empty)
+    }
+  }
+
+  def withTestProbeJournalSequenceActor(batchSize: Int, maxTries: Int, queryDelay: FiniteDuration)(f: (TestProbe, ActorRef) => Unit): Unit = {
+    val testProbe = TestProbe()
+    val config = JournalSequenceRetrievalConfig(batchSize = batchSize, maxTries = maxTries, queryDelay = queryDelay, maxBackoffQueryDelay = 4.seconds)
+    val mockDao = new TestProbeReadJournalDao(testProbe)
+    val actor = system.actorOf(JournalSequenceActor.props(mockDao, config))
+    try f(testProbe, actor) finally system.stop(actor)
+  }
+
+  override def afterAll(): Unit = {
+    system.terminate()
+    super.afterAll()
+  }
+}
+
+class PostgresJournalSequenceActorTest extends JournalSequenceActorTest("postgres-application.conf", isOracle = false) with PostgresCleaner
+
+class MySQLJournalSequenceActorTest extends JournalSequenceActorTest("mysql-application.conf", isOracle = false) with MysqlCleaner
+
+class OracleJournalSequenceActorTest extends JournalSequenceActorTest("oracle-application.conf", isOracle = true) with OracleCleaner
+
+class H2JournalSequenceActorTest extends JournalSequenceActorTest("h2-application.conf", isOracle = false) with H2Cleaner

--- a/src/test/scala/akka/persistence/jdbc/query/QueryTestSpec.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/QueryTestSpec.scala
@@ -199,6 +199,11 @@ abstract class QueryTestSpec(config: String) extends TestSpec(config) with ReadJ
     try f(refs.head, refs.drop(1).head, refs.drop(2).head) finally killActors(refs: _*)
   }
 
+  def withManyTestActors(amount: Int, seq: Int = 1)(f: Seq[ActorRef] => Unit): Unit = {
+    val refs = (seq until seq + amount).map(setupEmpty).toList
+    try f(refs) finally killActors(refs: _*)
+  }
+
   def withTags(payload: Any, tags: String*) = Tagged(payload, Set(tags: _*))
 
   override protected def afterAll(): Unit = {

--- a/src/test/scala/akka/persistence/jdbc/query/dao/TestProbeReadJournalDao.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/dao/TestProbeReadJournalDao.scala
@@ -1,0 +1,56 @@
+package akka.persistence.jdbc.query.dao
+
+import akka.NotUsed
+import akka.persistence.jdbc.query.dao.TestProbeReadJournalDao.JournalSequence
+import akka.persistence.{PersistentRepr, jdbc}
+import akka.stream.scaladsl.Source
+import akka.testkit.TestProbe
+import akka.util.Timeout
+import akka.pattern.ask
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.util.Try
+
+object TestProbeReadJournalDao {
+  case class JournalSequence(offset: Long, limit: Long)
+}
+
+/**
+ * Read journal dao where the journalSequence query is backed by a testprobe
+ */
+class TestProbeReadJournalDao(val probe: TestProbe) extends ReadJournalDao {
+  // Since the testprobe is instrumented by the test, it should respond very fast
+  implicit val askTimeout = Timeout(100.millis)
+
+  /**
+   * Returns distinct stream of persistenceIds
+   */
+  override def allPersistenceIdsSource(max: Long): Source[String, NotUsed] = ???
+
+  /**
+   * Returns a Source of bytes for certain tag from an offset. The result is sorted by
+   * created time asc thus the offset is relative to the creation time
+   */
+  override def eventsByTag(tag: String, offset: Long, maxOffset: Long, max: Long): Source[Try[(PersistentRepr, Set[String], jdbc.JournalRow)], NotUsed] = ???
+
+  /**
+   * Returns a Source of bytes for a certain persistenceId
+   */
+  override def messages(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long): Source[Try[PersistentRepr], NotUsed] = ???
+
+  /**
+   * @param offset Minimum value to retrieve
+   * @param limit  Maximum number of values to retrieve
+   * @return A Source of journal event sequence numbers (corresponding to the Ordering column)
+   */
+  override def journalSequence(offset: Long, limit: Long): Source[Long, NotUsed] = {
+    val f = probe.ref.ask(JournalSequence(offset, limit)).mapTo[scala.collection.immutable.Seq[Long]]
+    Source.fromFuture(f).mapConcat(identity)
+  }
+
+  /**
+   * @return The value of the maximum (ordering) id in the journal
+   */
+  override def maxJournalSequence(): Future[Long] = Future.successful(0)
+}


### PR DESCRIPTION
This is the fix for #96 

To resolve the issue I have implemented an actor (JournalSequenceActor) which is started on demand.

The responsibility of this actor is to keep track of the highest id (of the ordering column).
- Whenever gaps occur in the id sequence, the actor will query again for a configurable amount of tries (10 by default, with a default delay of 1 second).
- After the 10 (default) attempts, the actor will assume that the missing ids will never appear in the database anymore.
- When executing (current) EventsByTag queries, the JournalSequenceActor is used to retrieve the max ordering id, before querying. The actor can always respond immediately which the last known max ordering id.

Features
- No additional costs on the write side of the journal (with the footnote that I did add a unique index)
- Since the eventsByTag query uses the JournalSequenceActor it can know when querying the database is not needed.
- The JournalSequenceActor can recover one million sequential events in 3 seconds (see the tests)
- To recover fast when the database does have many gaps, the actor queries the max id from the database on startup. It will use this value after a after some delay (similar to when normal gaps have occurred)


