### PR TITLE
Batch writes

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -36,6 +36,15 @@ jdbc-journal {
 
   dao = "akka.persistence.jdbc.journal.dao.ByteArrayJournalDao"
 
+  // The size of the buffer used when queueing up events for batch writing. This number must be bigger then the number
+  // of events that may be written concurrently. In other words this number must be bigger than the number of persistent
+  // actors that are actively peristing at the same time.
+  bufferSize = 1000
+  // The maximum size of the batches in which journal rows will be inserted
+  batchSize = 400
+  // The maximum number of batch-inserts that may be running concurrently
+  parallelism = 8
+
   slick {
     driver = "slick.jdbc.PostgresProfile$"
     db {
@@ -146,11 +155,6 @@ jdbc-read-journal {
   # How many events to fetch in one query (replay) and keep buffered until they
   # are delivered downstreams.
   max-buffer-size = "500"
-
-  # How many events should be written in the bulk insert
-  # 250 seems a sweet spot for a macbook pro i7 16GB that runs postgres
-  # on docker-platform for mac 1.12.0-rc4-beta20 (build: 10404)
-  batch-size = "250"
 
   dao = "akka.persistence.jdbc.query.dao.ByteArrayReadJournalDao"
 

--- a/src/main/scala/akka/persistence/jdbc/config/AkkaPersistenceConfig.scala
+++ b/src/main/scala/akka/persistence/jdbc/config/AkkaPersistenceConfig.scala
@@ -72,6 +72,13 @@ class JournalPluginConfig(config: Config) {
   override def toString: String = s"JournalPluginConfig($tagSeparator,$dao)"
 }
 
+class BaseByteArrayJournalDaoConfig(config: Config) {
+  val bufferSize: Int = config.asInt("bufferSize", 1000)
+  val batchSize: Int = config.asInt("batchSize", 400)
+  val parallelism: Int = config.asInt("parallelism", 8)
+  override def toString: String = s"BaseByteArrayJournalDaoConfig($bufferSize,$batchSize,$parallelism)"
+}
+
 class ReadJournalPluginConfig(config: Config) {
   val tagSeparator: String = config.as[String]("tagSeparator", ",")
   val dao: String = config.as[String]("dao", "akka.persistence.jdbc.dao.bytea.readjournal.ByteArrayReadJournalDao")
@@ -89,6 +96,7 @@ class JournalConfig(config: Config) {
   val slickConfiguration = new SlickConfiguration(config)
   val journalTableConfiguration = new JournalTableConfiguration(config)
   val pluginConfig = new JournalPluginConfig(config)
+  val daoConfig = new BaseByteArrayJournalDaoConfig(config)
   override def toString: String = s"JournalConfig($slickConfiguration,$journalTableConfiguration,$pluginConfig)"
 }
 
@@ -105,6 +113,5 @@ class ReadJournalConfig(config: Config) {
   val pluginConfig = new ReadJournalPluginConfig(config)
   val refreshInterval: FiniteDuration = config.asFiniteDuration("refresh-interval", 1.second)
   val maxBufferSize: Int = config.as[String]("max-buffer-size", "500").toInt
-  val batchSize: Int = config.as[String]("batch-size", "250").toInt
   override def toString: String = s"ReadJournalConfig($slickConfiguration,$journalTableConfiguration,$pluginConfig,$refreshInterval,$maxBufferSize)"
 }

--- a/src/main/scala/akka/persistence/jdbc/journal/JdbcAsyncWriteJournal.scala
+++ b/src/main/scala/akka/persistence/jdbc/journal/JdbcAsyncWriteJournal.scala
@@ -23,7 +23,6 @@ import akka.persistence.jdbc.util.{SlickDatabase, SlickDriver}
 import akka.persistence.journal.AsyncWriteJournal
 import akka.persistence.{AtomicWrite, PersistentRepr}
 import akka.serialization.{Serialization, SerializationExtension}
-import akka.stream.scaladsl.Source
 import akka.stream.{ActorMaterializer, Materializer}
 import com.typesafe.config.Config
 import slick.jdbc.JdbcProfile
@@ -58,10 +57,10 @@ class JdbcAsyncWriteJournal(config: Config) extends AsyncWriteJournal {
     }
   }
 
-  override def asyncWriteMessages(messages: Seq[AtomicWrite]): Future[Seq[Try[Unit]]] =
-    Source(messages)
-      .via(journalDao.writeFlow)
-      .runFold(List.empty[Try[Unit]])(_ :+ _)
+  override def asyncWriteMessages(messages: Seq[AtomicWrite]): Future[Seq[Try[Unit]]] = {
+    // TODO like akka persistence cassandra, make sure that concurrent requests for the highest sequence number give the correct results
+    journalDao.asyncWriteMessages(messages)
+  }
 
   override def asyncDeleteMessagesTo(persistenceId: String, toSequenceNr: Long): Future[Unit] =
     journalDao.delete(persistenceId, toSequenceNr)

--- a/src/main/scala/akka/persistence/jdbc/journal/dao/JournalDao.scala
+++ b/src/main/scala/akka/persistence/jdbc/journal/dao/JournalDao.scala
@@ -20,6 +20,7 @@ import akka.NotUsed
 import akka.persistence.{AtomicWrite, PersistentRepr}
 import akka.stream.scaladsl._
 
+import scala.collection.immutable.Seq
 import scala.concurrent.Future
 import scala.util.Try
 
@@ -41,7 +42,7 @@ trait JournalDao {
   def messages(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long): Source[Try[PersistentRepr], NotUsed]
 
   /**
-   * Writes serialized messages
+   * @see [[akka.persistence.journal.AsyncWriteJournal.asyncWriteMessages(messages)]]
    */
-  def writeFlow: Flow[AtomicWrite, Try[Unit], NotUsed]
+  def asyncWriteMessages(messages: Seq[AtomicWrite]): Future[Seq[Try[Unit]]]
 }

--- a/src/main/scala/akka/persistence/jdbc/util/ConfigOps.scala
+++ b/src/main/scala/akka/persistence/jdbc/util/ConfigOps.scala
@@ -38,6 +38,10 @@ object ConfigOps {
       Try(config.getConfig(key))
         .getOrElse(default)
 
+    def asInt(key: String, default: Int): Int =
+      Try(config.getInt(key))
+        .getOrElse(default)
+
     def asBoolean(key: String, default: Boolean) =
       Try(config.getBoolean(key))
         .getOrElse(default)

--- a/src/test/resources/postgres-application.conf
+++ b/src/test/resources/postgres-application.conf
@@ -52,8 +52,6 @@ jdbc-read-journal {
 
   max-buffer-size = "500"
 
-  batch-size = "250"
-
   slick = ${slick}
   slick.db.numThreads = 20
   slick.db.maxConnections = 100


### PR DESCRIPTION
Implemented batch writing over multiple persistent actors. This results in a significant performance improvement.

I added result of the JDBCJournalPerfSpec below, I also added two testcases which test persist and persistAsync using a configurable amount of actors which are concurrently writing messages.

I would actually have wanted to test with more than 100 events, but the old implementation would quickly get circuit breaker timeouts...

This pull request also includes a second change: namely that it adheres to the spec for asyncReadHighestSequenceNr, which now reads the sequence number only if the previous write has completed (similar to akka-persistence-cassandra)

```
new implementation performance test output:
 PersistAsync()-ing 100 took 101 ms
 PersistAsync()-ing 100 took 37 ms
 PersistAsync()-ing 100 took 33 ms
 PersistAsync()-ing 100 took 36 ms
 PersistAsync()-ing 100 took 32 ms
 Average time: 48 ms
 Persist()-ing 100 took 1262 ms
 Persist()-ing 100 took 1324 ms
 Persist()-ing 100 took 1239 ms
 Persist()-ing 100 took 1263 ms
 Persist()-ing 100 took 1271 ms
 Average time: 1272 ms
 Recovering 100 took 23 ms
 Recovering 100 took 16 ms
 Recovering 100 took 16 ms
 Recovering 100 took 15 ms
 Recovering 100 took 15 ms
 Average time: 17 ms
 Persist()-ing 100 * 100 took 3372 ms
 Persist()-ing 100 * 100 took 3277 ms
 Persist()-ing 100 * 100 took 3211 ms
 Persist()-ing 100 * 100 took 3137 ms
 Persist()-ing 100 * 100 took 3088 ms
 Average time: 3217 ms
 persistAsync()-ing 100 * 100 took 347 ms
 persistAsync()-ing 100 * 100 took 351 ms
 persistAsync()-ing 100 * 100 took 287 ms
 persistAsync()-ing 100 * 100 took 300 ms
 persistAsync()-ing 100 * 100 took 317 ms
 Average time: 320 ms

old implementation performance test output
 PersistAsync()-ing 100 took 1401 ms
 PersistAsync()-ing 100 took 1271 ms
 PersistAsync()-ing 100 took 1294 ms
 PersistAsync()-ing 100 took 1285 ms
 PersistAsync()-ing 100 took 1263 ms
 Average time: 1303 ms
 Persist()-ing 100 took 1376 ms
 Persist()-ing 100 took 1344 ms
 Persist()-ing 100 took 1280 ms
 Persist()-ing 100 took 1254 ms
 Persist()-ing 100 took 1268 ms
 Average time: 1304 ms
 Recovering 100 took 18 ms
 Recovering 100 took 15 ms
 Recovering 100 took 14 ms
 Recovering 100 took 15 ms
 Recovering 100 took 13 ms
 Average time: 15 ms
 Persist()-ing 100 * 100 took 11020 ms
 Persist()-ing 100 * 100 took 11044 ms
 Persist()-ing 100 * 100 took 11068 ms
 Persist()-ing 100 * 100 took 10916 ms
 Persist()-ing 100 * 100 took 10936 ms
 Average time: 10997 ms
 persistAsync()-ing 100 * 100 took 11066 ms
 persistAsync()-ing 100 * 100 took 10831 ms
 persistAsync()-ing 100 * 100 took 11051 ms
 persistAsync()-ing 100 * 100 took 10846 ms
 persistAsync()-ing 100 * 100 took 10966 ms
 Average time: 10952 ms
```