### PR TITLE
H2 :: Fix schema name quoting

### DIFF
--- a/src/test/resources/schema/h2/h2-schema.sql
+++ b/src/test/resources/schema/h2/h2-schema.sql
@@ -1,23 +1,23 @@
-DROP TABLE IF EXISTS PUBLIC.journal;
+DROP TABLE IF EXISTS PUBLIC."journal";
 
-CREATE TABLE IF NOT EXISTS PUBLIC.journal (
-  ordering BIGINT AUTO_INCREMENT,
-  persistence_id VARCHAR(255) NOT NULL,
-  sequence_number BIGINT NOT NULL,
-  deleted BOOLEAN DEFAULT FALSE,
-  tags VARCHAR(255) DEFAULT NULL,
-  message BYTEA NOT NULL,
-  PRIMARY KEY(persistence_id, sequence_number)
+CREATE TABLE IF NOT EXISTS PUBLIC."journal" (
+  "ordering" BIGINT AUTO_INCREMENT,
+  "persistence_id" VARCHAR(255) NOT NULL,
+  "sequence_number" BIGINT NOT NULL,
+  "deleted" BOOLEAN DEFAULT FALSE,
+  "tags" VARCHAR(255) DEFAULT NULL,
+  "message" BYTEA NOT NULL,
+  PRIMARY KEY("persistence_id", "sequence_number")
 );
 
-CREATE UNIQUE INDEX journal_ordering_idx ON PUBLIC.journal(ordering);
+CREATE UNIQUE INDEX "journal_ordering_idx" ON PUBLIC."journal"("ordering");
 
-DROP TABLE IF EXISTS PUBLIC.snapshot;
+DROP TABLE IF EXISTS PUBLIC."snapshot";
 
-CREATE TABLE IF NOT EXISTS PUBLIC.snapshot (
-  persistence_id VARCHAR(255) NOT NULL,
-  sequence_number BIGINT NOT NULL,
-  created BIGINT NOT NULL,
-  snapshot BYTEA NOT NULL,
-  PRIMARY KEY(persistence_id, sequence_number)
+CREATE TABLE IF NOT EXISTS PUBLIC."snapshot" (
+  "persistence_id" VARCHAR(255) NOT NULL,
+  "sequence_number" BIGINT NOT NULL,
+  "created" BIGINT NOT NULL,
+  "snapshot" BYTEA NOT NULL,
+  PRIMARY KEY("persistence_id", "sequence_number")
 );


### PR DESCRIPTION
I continued trying to work with H2 and I met an error saying that table "snapshot" did not exist. So I investigate and figured out that double quotes were missing into the h2-schema.sql.

I fixed it and now it works fine.