### PR TITLE
improved sbtopts

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,4 +1,5 @@
 -J-Xms512M
 -J-Xmx4096M
+-J-XX:-UseConcMarkSweepGC
 -J-XX:+UseG1GC
--J-XX:+CMSClassUnloadingEnabled
+-J-XX:MaxGCPauseMillis=200


### PR DESCRIPTION
This PR explicitly removes the default GC  (`-J-XX:-UseConcMarkSweepGC`).

It seems that some jvm versions will complain when adding G1GC, but not explicitly disabling the default GC.

I'm getting the following error:
```
Conflicting collector combinations in option list; please refer to the release notes for the combinations allowed
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.`
```

JVM:
```
java version "1.8.0_121"
Java(TM) SE Runtime Environment (build 1.8.0_121-b13)
Java HotSpot(TM) 64-Bit Server VM (build 25.121-b13, mixed mode)
```