### PR TITLE
Changed oracle test-docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ before_install:
 #  - docker pull mysql
 #  - docker run --name mysql -d -p 127.0.0.1:3306:3306 -e MYSQL_ROOT_PASSWORD=root mysql
 #  - docker inspect mysql
-  - docker pull wnameless/oracle-xe-11g
-  - docker run --name oracle -d -p 127.0.0.1:1521:1521 -e ORACLE_ALLOW_REMOTE=true wnameless/oracle-xe-11g
+  - docker pull alexeiled/docker-oracle-xe-11g
+  - docker run --name oracle -d -p 127.0.0.1:1521:1521 -e ORACLE_ALLOW_REMOTE=true alexeiled/docker-oracle-xe-11g
   - docker inspect oracle
   - docker ps -a
 scala:

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -18,7 +18,7 @@ mysql:
     - "3306:3306" # credentials (root:root)
 
 oracle:
-  image: wnameless/oracle-xe-11g
+  image: alexeiled/docker-oracle-xe-11g 
   container_name: oracle-test
   environment:
     - "TZ=Europe/Amsterdam"


### PR DESCRIPTION
The travis build was broken. Because the `wnameless/oracle-xe-11g` image no longer exists on dockerhub. I chose the most-starred oracle-xe-11g instead, which should resolve our problems.