### PR TITLE
currentEventsByTag fix ( #124 ) + exclusive offsets queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,22 @@ sys.addShutdownHook(system.terminate())
 ```
 
 ## Changelog  
+
+### 2.8.0 (2017-10-27)
+For use with Akka 2.4.x only, please use release 3.0.1 with Akka 2.5
+
+Changes since v2.7.0
+  - **This is a breaking change!**  EventsByTag query treats the offset as exclusive instead of inclusive. All users of
+    the eventsByTag query can now reuse the `Offset` from the last received `EventEnvelope` to resume the query.
+  - Align JournalTables with the sql schemas (issue #130)
+  - Current events by tag fix (issue #124) 
+  - fixes for max ordering jump (issue #126)
+  - Allow configuration of ask timeout when querying maxOrdering (issue #123)
+  - sbt-release 1.0.6
+  - Merged PRs #122, #127, #128, #129, #132, #133. Thanks to [Jimin Hsieh][jiminhsieh],
+    [Renato Cavalcanti][renatocaval], [Sean Sullivan][sullis],
+    [Ruud Welling][WellingR], [Adam Chaulk](acchaulk).
+    
 ### 2.7.0 (2017-08-29)
 Changes since v2.4.18.2
   - For use with Akka 2.4.x only, please use release 3.0.0 with Akka 2.5

--- a/src/main/scala/akka/persistence/jdbc/query/dao/ByteArrayReadJournalDao.scala
+++ b/src/main/scala/akka/persistence/jdbc/query/dao/ByteArrayReadJournalDao.scala
@@ -104,11 +104,11 @@ trait OracleReadJournalDao extends ReadJournalDao {
             FROM (
               SELECT * FROM #$theTableName
               WHERE "#$tags" LIKE $theTag
-              AND "#$ordering" >= $theOffset
+              AND "#$ordering" > $theOffset
               AND "#$ordering" <= $maxOffset
               ORDER BY "#$ordering"
             )
-            WHERE rownum < $max""".as[JournalRow]
+            WHERE rownum <= $max""".as[JournalRow]
         )
       }.via(serializer.deserializeFlow)
     } else {

--- a/src/main/scala/akka/persistence/jdbc/query/dao/ReadJournalQueries.scala
+++ b/src/main/scala/akka/persistence/jdbc/query/dao/ReadJournalQueries.scala
@@ -47,7 +47,7 @@ class ReadJournalQueries(val profile: JdbcProfile, override val journalTableCfg:
     JournalTable
       .filter(_.tags like tag)
       .sortBy(_.ordering.asc)
-      .filter(row => row.ordering >= offset && row.ordering <= maxOffset)
+      .filter(row => row.ordering > offset && row.ordering <= maxOffset)
       .take(max)
   val eventsByTag = Compiled(_eventsByTag _)
 

--- a/src/test/resources/h2-application.conf
+++ b/src/test/resources/h2-application.conf
@@ -27,9 +27,10 @@ jdbc-journal {
   }
 
   event-adapter-bindings {
-    "akka.persistence.jdbc.query.EventAdapterTest$Event"        = test-write-event-adapter
-    "akka.persistence.jdbc.query.EventAdapterTest$TaggedEvent"  = test-write-event-adapter
-    "akka.persistence.jdbc.query.EventAdapterTest$EventAdapted" = test-read-event-adapter
+    "akka.persistence.jdbc.query.EventAdapterTest$Event"            = test-write-event-adapter
+    "akka.persistence.jdbc.query.EventAdapterTest$TaggedEvent"      = test-write-event-adapter
+    "akka.persistence.jdbc.query.EventAdapterTest$TaggedAsyncEvent" = test-write-event-adapter
+    "akka.persistence.jdbc.query.EventAdapterTest$EventAdapted"     = test-read-event-adapter
   }
 
 }

--- a/src/test/resources/mysql-application.conf
+++ b/src/test/resources/mysql-application.conf
@@ -30,9 +30,10 @@ jdbc-journal {
   }
 
   event-adapter-bindings {
-    "akka.persistence.jdbc.query.EventAdapterTest$Event"        = test-write-event-adapter
-    "akka.persistence.jdbc.query.EventAdapterTest$TaggedEvent"  = test-write-event-adapter
-    "akka.persistence.jdbc.query.EventAdapterTest$EventAdapted" = test-read-event-adapter
+    "akka.persistence.jdbc.query.EventAdapterTest$Event"            = test-write-event-adapter
+    "akka.persistence.jdbc.query.EventAdapterTest$TaggedEvent"      = test-write-event-adapter
+    "akka.persistence.jdbc.query.EventAdapterTest$TaggedAsyncEvent" = test-write-event-adapter
+    "akka.persistence.jdbc.query.EventAdapterTest$EventAdapted"     = test-read-event-adapter
   }
 }
 

--- a/src/test/resources/oracle-application.conf
+++ b/src/test/resources/oracle-application.conf
@@ -35,9 +35,10 @@ jdbc-journal {
   }
 
   event-adapter-bindings {
-    "akka.persistence.jdbc.query.EventAdapterTest$Event"        = test-write-event-adapter
-    "akka.persistence.jdbc.query.EventAdapterTest$TaggedEvent"  = test-write-event-adapter
-    "akka.persistence.jdbc.query.EventAdapterTest$EventAdapted" = test-read-event-adapter
+    "akka.persistence.jdbc.query.EventAdapterTest$Event"            = test-write-event-adapter
+    "akka.persistence.jdbc.query.EventAdapterTest$TaggedEvent"      = test-write-event-adapter
+    "akka.persistence.jdbc.query.EventAdapterTest$TaggedAsyncEvent" = test-write-event-adapter
+    "akka.persistence.jdbc.query.EventAdapterTest$EventAdapted"     = test-read-event-adapter
   }
 
 }

--- a/src/test/resources/postgres-application.conf
+++ b/src/test/resources/postgres-application.conf
@@ -30,9 +30,10 @@ jdbc-journal {
   }
 
   event-adapter-bindings {
-    "akka.persistence.jdbc.query.EventAdapterTest$Event"        = test-write-event-adapter
-    "akka.persistence.jdbc.query.EventAdapterTest$TaggedEvent"  = test-write-event-adapter
-    "akka.persistence.jdbc.query.EventAdapterTest$EventAdapted" = test-read-event-adapter
+    "akka.persistence.jdbc.query.EventAdapterTest$Event"            = test-write-event-adapter
+    "akka.persistence.jdbc.query.EventAdapterTest$TaggedEvent"      = test-write-event-adapter
+    "akka.persistence.jdbc.query.EventAdapterTest$TaggedAsyncEvent" = test-write-event-adapter
+    "akka.persistence.jdbc.query.EventAdapterTest$EventAdapted"     = test-read-event-adapter
   }
 
 }

--- a/src/test/scala/akka/persistence/jdbc/SimpleSpec.scala
+++ b/src/test/scala/akka/persistence/jdbc/SimpleSpec.scala
@@ -16,7 +16,7 @@
 
 package akka.persistence.jdbc
 
-import akka.actor.{ActorRef, ActorSystem, PoisonPill}
+import akka.actor.{ActorRef, ActorSystem}
 import akka.persistence.jdbc.util.ClasspathResources
 import akka.testkit.TestProbe
 import org.scalatest._
@@ -42,7 +42,7 @@ trait SimpleSpec extends FlatSpec
     val tp = TestProbe()
     actors.foreach { (actor: ActorRef) =>
       tp watch actor
-      actor ! PoisonPill
+      system.stop(actor)
       tp.expectTerminated(actor)
     }
   }

--- a/src/test/scala/akka/persistence/jdbc/TestSpec.scala
+++ b/src/test/scala/akka/persistence/jdbc/TestSpec.scala
@@ -23,7 +23,7 @@ import akka.persistence.jdbc.config.JournalConfig
 import akka.persistence.jdbc.util.{DropCreate, SlickDatabase}
 import akka.serialization.SerializationExtension
 import akka.util.Timeout
-import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.config.{Config, ConfigFactory, ConfigValue}
 import org.scalatest.BeforeAndAfterAll
 
 import scala.concurrent.duration._
@@ -32,7 +32,10 @@ import scala.util.Try
 
 abstract class TestSpec(override val config: Config) extends SimpleSpec with MaterializerSpec with DropCreate with BeforeAndAfterAll {
 
-  def this(config: String = "postgres-application.conf") = this(ConfigFactory.load(config))
+  def this(config: String = "postgres-application.conf", configOverrides: Map[String, ConfigValue] = Map.empty) =
+    this(configOverrides.foldLeft(ConfigFactory.load(config)) {
+      case (conf, (path, configValue)) => conf.withValue(path, configValue)
+    })
 
   implicit val ec: ExecutionContextExecutor = system.dispatcher
   val log: LoggingAdapter = Logging(system, this.getClass)

--- a/src/test/scala/akka/persistence/jdbc/query/EventAdapterTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/EventAdapterTest.scala
@@ -30,6 +30,8 @@ object EventAdapterTest {
 
   case class TaggedEvent(event: Event, tag: String)
 
+  case class TaggedAsyncEvent(event: Event, tag: String)
+
   case class EventAdapted(value: String) {
     def restored = EventRestored(value)
   }
@@ -46,9 +48,10 @@ object EventAdapterTest {
     override def manifest(event: Any): String = ""
 
     override def toJournal(event: Any): Any = event match {
-      case e: Event                    => e.adapted
-      case TaggedEvent(e: Event, tags) => Tagged(e.adapted, Set(tags))
-      case _                           => event
+      case e: Event                        => e.adapted
+      case TaggedEvent(e: Event, tag)      => Tagged(e.adapted, Set(tag))
+      case TaggedAsyncEvent(e: Event, tag) => Tagged(e.adapted, Set(tag))
+      case _                               => event
     }
   }
 
@@ -91,7 +94,7 @@ abstract class EventAdapterTest(config: String) extends QueryTestSpec(config) {
         countJournal.futureValue shouldBe 3
       }
 
-      withEventsByTag(10.seconds)("event", 2) { tp =>
+      withEventsByTag(10.seconds)("event", 1) { tp =>
 
         tp.request(Int.MaxValue)
         tp.expectNext(EventEnvelope(2, "my-2", 1, EventRestored("2")))
@@ -163,7 +166,6 @@ abstract class EventAdapterTest(config: String) extends QueryTestSpec(config) {
 
       withCurrentEventsByTag()("event", 1) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNextPF { case EventEnvelope(1, _, _, EventRestored("1")) => }
         tp.expectNextPF { case EventEnvelope(2, _, _, EventRestored("2")) => }
         tp.expectNextPF { case EventEnvelope(3, _, _, EventRestored("3")) => }
         tp.expectComplete()
@@ -171,18 +173,11 @@ abstract class EventAdapterTest(config: String) extends QueryTestSpec(config) {
 
       withCurrentEventsByTag()("event", 2) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNextPF { case EventEnvelope(2, _, _, EventRestored("2")) => }
         tp.expectNextPF { case EventEnvelope(3, _, _, EventRestored("3")) => }
         tp.expectComplete()
       }
 
       withCurrentEventsByTag()("event", 3) { tp =>
-        tp.request(Int.MaxValue)
-        tp.expectNextPF { case EventEnvelope(3, _, _, EventRestored("3")) => }
-        tp.expectComplete()
-      }
-
-      withCurrentEventsByTag()("event", 4) { tp =>
         tp.request(Int.MaxValue)
         tp.expectComplete()
       }

--- a/src/test/scala/akka/persistence/jdbc/query/QueryTestSpec.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/QueryTestSpec.scala
@@ -20,7 +20,7 @@ import akka.actor.{ActorRef, ActorSystem, Props}
 import akka.event.LoggingReceive
 import akka.persistence.PersistentActor
 import akka.persistence.jdbc.TestSpec
-import akka.persistence.jdbc.query.EventAdapterTest.{Event, TaggedEvent}
+import akka.persistence.jdbc.query.EventAdapterTest.{Event, TaggedAsyncEvent, TaggedEvent}
 import akka.persistence.jdbc.query.JournalSequenceActor.{GetMaxOrderingId, MaxOrderingId}
 import akka.persistence.jdbc.query.javadsl.{JdbcReadJournal => JavaJdbcReadJournal}
 import akka.persistence.jdbc.query.scaladsl.JdbcReadJournal
@@ -32,6 +32,7 @@ import akka.stream.testkit.TestSubscriber
 import akka.stream.testkit.javadsl.{TestSink => JavaSink}
 import akka.stream.testkit.scaladsl.TestSink
 import akka.util.Timeout
+import com.typesafe.config.ConfigValue
 import slick.jdbc.PostgresProfile.api._
 
 import scala.concurrent.duration.{FiniteDuration, _}
@@ -96,7 +97,7 @@ trait ScalaJdbcReadJournalOperations extends ReadJournalOperations {
   def latestOrdering: Future[Long] = {
     import akka.pattern.ask
     implicit val askTimeout = Timeout(100.millis)
-    readJournal.orderingActor.ask(GetMaxOrderingId)
+    readJournal.journalSequenceActor.ask(GetMaxOrderingId)
       .mapTo[MaxOrderingId]
       .map(_.maxOrdering)
   }
@@ -150,7 +151,7 @@ trait JavaDslJdbcReadJournalOperations extends ReadJournalOperations {
       .map(_.sum)
 }
 
-abstract class QueryTestSpec(config: String) extends TestSpec(config) with ReadJournalOperations {
+abstract class QueryTestSpec(config: String, configOverrides: Map[String, ConfigValue] = Map.empty) extends TestSpec(config, configOverrides) with ReadJournalOperations {
 
   case class DeleteCmd(toSequenceNr: Long = Long.MaxValue) extends Serializable
 
@@ -187,6 +188,10 @@ abstract class QueryTestSpec(config: String) extends TestSpec(config) with ReadJ
 
       case event @ TaggedEvent(payload: Event, tag) =>
         persist(event) { evt =>
+          sender() ! akka.actor.Status.Success((payload, tag))
+        }
+      case event @ TaggedAsyncEvent(payload: Event, tag) =>
+        persistAsync(event) { evt =>
           sender() ! akka.actor.Status.Success((payload, tag))
         }
     }

--- a/src/test/scala/akka/persistence/jdbc/util/DropCreate.scala
+++ b/src/test/scala/akka/persistence/jdbc/util/DropCreate.scala
@@ -38,6 +38,7 @@ trait DropCreate extends ClasspathResources {
   def db: JdbcBackend#Database
 
   val listOfOracleDropQueries = List(
+    """ALTER SESSION SET ddl_lock_timeout = 15""", // (ddl lock timeout in seconds) this allows tests which are still writing to the db to finish gracefully
     """DROP TABLE "journal" CASCADE CONSTRAINT""",
     """DROP TABLE "snapshot" CASCADE CONSTRAINT""",
     """DROP TABLE "deleted_to" CASCADE CONSTRAINT""",


### PR DESCRIPTION
This PR bring the fix for `currentEventsByTag` and the exclusive offsets queries that was never merged in akka24.