### PR TITLE
Test improvements

### DIFF
--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -37,7 +37,7 @@
 
     <!--<logger name="slick.util.AsyncExecutor" level="DEBUG" />-->
 
-    <root level="error">
+    <root level="INFO">
         <appender-ref ref="console"/>
     </root>
 

--- a/src/test/scala/akka/persistence/jdbc/TablesTestSpec.scala
+++ b/src/test/scala/akka/persistence/jdbc/TablesTestSpec.scala
@@ -20,7 +20,7 @@ import akka.persistence.jdbc.config._
 import com.typesafe.config.ConfigFactory
 import org.scalatest.{FlatSpec, Matchers}
 
-class TablesTestSpec extends FlatSpec with Matchers {
+abstract class TablesTestSpec extends FlatSpec with Matchers {
 
   def toColumnName[A](tableName: String)(columnName: String): String = s"$tableName.$columnName"
 

--- a/src/test/scala/akka/persistence/jdbc/TestSpec.scala
+++ b/src/test/scala/akka/persistence/jdbc/TestSpec.scala
@@ -39,8 +39,8 @@ abstract class TestSpec(override val config: Config) extends SimpleSpec with Mat
 
   implicit val ec: ExecutionContextExecutor = system.dispatcher
   val log: LoggingAdapter = Logging(system, this.getClass)
-  implicit val pc: PatienceConfig = PatienceConfig(timeout = 40.minutes)
-  implicit val timeout = Timeout(40.minutes)
+  implicit val pc: PatienceConfig = PatienceConfig(timeout = 1.minute)
+  implicit val timeout = Timeout(1.minute)
   val serialization = SerializationExtension(system)
 
   val cfg = system.settings.config.getConfig("jdbc-journal")

--- a/src/test/scala/akka/persistence/jdbc/query/AllPersistenceIdsTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/AllPersistenceIdsTest.scala
@@ -22,40 +22,40 @@ abstract class AllPersistenceIdsTest(config: String) extends QueryTestSpec(confi
   it should "not terminate the stream when there are not pids" in
     withPersistenceIds() { tp =>
       tp.request(1)
-      tp.expectNoMsg(100.millis)
+      tp.expectNoMessage(100.millis)
       tp.cancel()
-      tp.expectNoMsg(100.millis)
+      tp.expectNoMessage(100.millis)
     }
 
   it should "find persistenceIds for actors" in
     withTestActors() { (actor1, actor2, actor3) =>
       withPersistenceIds() { tp =>
         tp.request(10)
-        tp.expectNoMsg(100.millis)
+        tp.expectNoMessage(100.millis)
 
         actor1 ! 1
         tp.expectNext(ExpectNextTimeout, "my-1")
-        tp.expectNoMsg(100.millis)
+        tp.expectNoMessage(100.millis)
 
         actor2 ! 1
         tp.expectNext(ExpectNextTimeout, "my-2")
-        tp.expectNoMsg(100.millis)
+        tp.expectNoMessage(100.millis)
 
         actor3 ! 1
         tp.expectNext(ExpectNextTimeout, "my-3")
-        tp.expectNoMsg(100.millis)
+        tp.expectNoMessage(100.millis)
 
         actor1 ! 1
-        tp.expectNoMsg(100.millis)
+        tp.expectNoMessage(100.millis)
 
         actor2 ! 1
-        tp.expectNoMsg(100.millis)
+        tp.expectNoMessage(100.millis)
 
         actor3 ! 1
-        tp.expectNoMsg(100.millis)
+        tp.expectNoMessage(100.millis)
 
         tp.cancel()
-        tp.expectNoMsg(100.millis)
+        tp.expectNoMessage(100.millis)
       }
     }
 }

--- a/src/test/scala/akka/persistence/jdbc/query/EventAdapterTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/EventAdapterTest.scala
@@ -68,15 +68,15 @@ abstract class EventAdapterTest(config: String) extends QueryTestSpec(config) {
     withTestActors() { (actor1, actor2, actor3) =>
       withEventsByPersistenceId()("my-1", 0) { tp =>
         tp.request(10)
-        tp.expectNoMsg(100.millis)
+        tp.expectNoMessage(100.millis)
 
         actor1 ! Event("1")
         tp.expectNext(ExpectNextTimeout, EventEnvelope(Sequence(1), "my-1", 1, EventRestored("1")))
-        tp.expectNoMsg(100.millis)
+        tp.expectNoMessage(100.millis)
 
         actor1 ! Event("2")
         tp.expectNext(ExpectNextTimeout, EventEnvelope(Sequence(2), "my-1", 2, EventRestored("2")))
-        tp.expectNoMsg(100.millis)
+        tp.expectNoMessage(100.millis)
         tp.cancel()
       }
     }
@@ -99,12 +99,12 @@ abstract class EventAdapterTest(config: String) extends QueryTestSpec(config) {
         tp.request(Int.MaxValue)
         tp.expectNext(EventEnvelope(Sequence(2), "my-2", 1, EventRestored("2")))
         tp.expectNext(EventEnvelope(Sequence(3), "my-3", 1, EventRestored("3")))
-        tp.expectNoMsg(NoMsgTime)
+        tp.expectNoMessage(NoMsgTime)
 
         actor1 ! TaggedEvent(Event("1"), "event")
         tp.expectNext(EventEnvelope(Sequence(4), "my-1", 2, EventRestored("1")))
         tp.cancel()
-        tp.expectNoMsg(NoMsgTime)
+        tp.expectNoMessage(NoMsgTime)
       }
     }
   }

--- a/src/test/scala/akka/persistence/jdbc/query/EventAdapterTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/EventAdapterTest.scala
@@ -84,7 +84,7 @@ abstract class EventAdapterTest(config: String) extends QueryTestSpec(config) {
   }
 
   it should "apply event adapters when querying events by tag from an offset" in {
-    withTestActors() { (actor1, actor2, actor3) =>
+    withTestActors(replyToMessages = true) { (actor1, actor2, actor3) =>
 
       (actor1 ? TaggedEvent(Event("1"), "event")).futureValue
       (actor2 ? TaggedEvent(Event("2"), "event")).futureValue
@@ -101,7 +101,7 @@ abstract class EventAdapterTest(config: String) extends QueryTestSpec(config) {
         tp.expectNext(EventEnvelope(Sequence(3), "my-3", 1, EventRestored("3")))
         tp.expectNoMessage(NoMsgTime)
 
-        actor1 ! TaggedEvent(Event("1"), "event")
+        actor1 ? TaggedEvent(Event("1"), "event")
         tp.expectNext(EventEnvelope(Sequence(4), "my-1", 2, EventRestored("1")))
         tp.cancel()
         tp.expectNoMessage(NoMsgTime)
@@ -147,7 +147,7 @@ abstract class EventAdapterTest(config: String) extends QueryTestSpec(config) {
   }
 
   it should "apply event adapters when querying all current events by tag" in {
-    withTestActors() { (actor1, actor2, actor3) =>
+    withTestActors(replyToMessages = true) { (actor1, actor2, actor3) =>
       (actor1 ? TaggedEvent(Event("1"), "event")).futureValue
       (actor2 ? TaggedEvent(Event("2"), "event")).futureValue
       (actor3 ? TaggedEvent(Event("3"), "event")).futureValue

--- a/src/test/scala/akka/persistence/jdbc/query/EventsByPersistenceIdTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/EventsByPersistenceIdTest.scala
@@ -25,9 +25,9 @@ abstract class EventsByPersistenceIdTest(config: String) extends QueryTestSpec(c
   it should "not find any events for unknown pid" in {
     withEventsByPersistenceId()("unkown-pid", 0L, Long.MaxValue) { tp =>
       tp.request(1)
-      tp.expectNoMsg(100.millis)
+      tp.expectNoMessage(100.millis)
       tp.cancel()
-      tp.expectNoMsg(100.millis)
+      tp.expectNoMessage(100.millis)
     }
   }
 
@@ -130,15 +130,15 @@ abstract class EventsByPersistenceIdTest(config: String) extends QueryTestSpec(c
     withTestActors() { (actor1, actor2, actor3) =>
       withEventsByPersistenceId()("my-1", 0) { tp =>
         tp.request(10)
-        tp.expectNoMsg(100.millis)
+        tp.expectNoMessage(100.millis)
 
         actor1 ! 1
         tp.expectNext(ExpectNextTimeout, EventEnvelope(Sequence(1), "my-1", 1, 1))
-        tp.expectNoMsg(100.millis)
+        tp.expectNoMessage(100.millis)
 
         actor1 ! 2
         tp.expectNext(ExpectNextTimeout, EventEnvelope(Sequence(2), "my-1", 2, 2))
-        tp.expectNoMsg(100.millis)
+        tp.expectNoMessage(100.millis)
         tp.cancel()
       }
     }
@@ -148,27 +148,27 @@ abstract class EventsByPersistenceIdTest(config: String) extends QueryTestSpec(c
     withTestActors() { (actor1, actor2, actor3) =>
       withEventsByPersistenceId()("my-1", 0, Long.MaxValue) { tp =>
         tp.request(10)
-        tp.expectNoMsg(100.millis)
+        tp.expectNoMessage(100.millis)
 
         actor1 ! 1
         tp.expectNext(ExpectNextTimeout, EventEnvelope(Sequence(1), "my-1", 1, 1))
-        tp.expectNoMsg(100.millis)
+        tp.expectNoMessage(100.millis)
 
         actor1 ! 2
         tp.expectNext(ExpectNextTimeout, EventEnvelope(Sequence(2), "my-1", 2, 2))
-        tp.expectNoMsg(100.millis)
+        tp.expectNoMessage(100.millis)
 
         actor2 ! 1
         actor2 ! 2
         actor2 ! 3
-        tp.expectNoMsg(100.millis)
+        tp.expectNoMessage(100.millis)
 
         actor1 ! 3
         tp.expectNext(ExpectNextTimeout, EventEnvelope(Sequence(3), "my-1", 3, 3))
-        tp.expectNoMsg(100.millis)
+        tp.expectNoMessage(100.millis)
 
         tp.cancel()
-        tp.expectNoMsg(100.millis)
+        tp.expectNoMessage(100.millis)
       }
     }
   }
@@ -190,7 +190,7 @@ abstract class EventsByPersistenceIdTest(config: String) extends QueryTestSpec(c
         tp.expectNext(ExpectNextTimeout, EventEnvelope(Sequence(2), "my-2", 2, 2))
         tp.request(1)
         tp.expectNext(ExpectNextTimeout, EventEnvelope(Sequence(3), "my-2", 3, 3))
-        tp.expectNoMsg(100.millis)
+        tp.expectNoMessage(100.millis)
 
         actor2 ! 5
         actor2 ! 6
@@ -204,10 +204,10 @@ abstract class EventsByPersistenceIdTest(config: String) extends QueryTestSpec(c
         tp.expectNext(ExpectNextTimeout, EventEnvelope(Sequence(4), "my-2", 4, 5))
         tp.expectNext(ExpectNextTimeout, EventEnvelope(Sequence(5), "my-2", 5, 6))
         tp.expectNext(ExpectNextTimeout, EventEnvelope(Sequence(6), "my-2", 6, 7))
-        tp.expectNoMsg(100.millis)
+        tp.expectNoMessage(100.millis)
 
         tp.cancel()
-        tp.expectNoMsg(100.millis)
+        tp.expectNoMessage(100.millis)
       }
     }
   }

--- a/src/test/scala/akka/persistence/jdbc/query/EventsByTagTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/EventsByTagTest.scala
@@ -60,7 +60,7 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config, con
   }
 
   it should "find all events by tag" in {
-    withTestActors() { (actor1, actor2, actor3) =>
+    withTestActors(replyToMessages = true) { (actor1, actor2, actor3) =>
       (actor1 ? withTags(1, "number")).futureValue
       (actor2 ? withTags(2, "number")).futureValue
       (actor3 ? withTags(3, "number")).futureValue
@@ -116,13 +116,13 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config, con
         tp.expectNext(EventEnvelope(Sequence(3), "my-3", 1, 3))
         tp.expectNoMessage(NoMsgTime)
 
-        actor1 ! withTags(1, "number")
+        actor1 ? withTags(1, "number")
         tp.expectNext(EventEnvelope(Sequence(4), "my-1", 2, 1))
 
-        actor1 ! withTags(1, "number")
+        actor1 ? withTags(1, "number")
         tp.expectNext(EventEnvelope(Sequence(5), "my-1", 3, 1))
 
-        actor1 ! withTags(1, "number")
+        actor1 ? withTags(1, "number")
         tp.expectNext(EventEnvelope(Sequence(6), "my-1", 4, 1))
         tp.cancel()
         tp.expectNoMessage(NoMsgTime)
@@ -159,7 +159,7 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config, con
   }
 
   it should "find events by tag from an offset" in {
-    withTestActors() { (actor1, actor2, actor3) =>
+    withTestActors(replyToMessages = true) { (actor1, actor2, actor3) =>
       (actor1 ? withTags(1, "number")).futureValue
       (actor2 ? withTags(2, "number")).futureValue
       (actor3 ? withTags(3, "number")).futureValue
@@ -174,7 +174,7 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config, con
         tp.expectNext(EventEnvelope(Sequence(3), "my-3", 1, 3))
         tp.expectNoMessage(NoMsgTime)
 
-        actor1 ! withTags(1, "number")
+        actor1 ? withTags(1, "number")
         tp.expectNext(EventEnvelope(Sequence(4), "my-1", 2, 1))
         tp.cancel()
         tp.expectNoMessage(NoMsgTime)
@@ -227,7 +227,7 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config, con
   }
 
   it should "persist and find tagged events when stored with multiple tags" in {
-    withTestActors() { (actor1, actor2, actor3) =>
+    withTestActors(replyToMessages = true) { (actor1, actor2, actor3) =>
       (actor1 ? withTags(1, "one", "1", "prime")).futureValue
       (actor1 ? withTags(2, "two", "2", "prime")).futureValue
       (actor1 ? withTags(3, "three", "3", "prime")).futureValue
@@ -303,7 +303,7 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config, con
   def timeoutMultiplier: Int = 1
 
   it should "show the configured performance characteristics" in {
-    withTestActors() { (actor1, actor2, actor3) =>
+    withTestActors(replyToMessages = true) { (actor1, actor2, actor3) =>
       def sendMessagesWithTag(tag: String, numberOfMessagesPerActor: Int): Future[Done] = {
         val futures = for (actor <- Seq(actor1, actor2, actor3); i <- 1 to numberOfMessagesPerActor) yield {
           actor ? TaggedAsyncEvent(Event(i.toString), tag)

--- a/src/test/scala/akka/persistence/jdbc/query/EventsByTagTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/EventsByTagTest.scala
@@ -53,7 +53,7 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config, con
 
       withEventsByTag()("unknown", NoOffset) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNoMsg(NoMsgTime)
+        tp.expectNoMessage(NoMsgTime)
         tp.cancel()
       }
     }
@@ -104,9 +104,9 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config, con
 
       withEventsByTag()("number", Sequence(3)) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNoMsg(NoMsgTime)
+        tp.expectNoMessage(NoMsgTime)
         tp.cancel()
-        tp.expectNoMsg(NoMsgTime)
+        tp.expectNoMessage(NoMsgTime)
       }
 
       withEventsByTag()("number", NoOffset) { tp =>
@@ -114,7 +114,7 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config, con
         tp.expectNext(EventEnvelope(Sequence(1), "my-1", 1, 1))
         tp.expectNext(EventEnvelope(Sequence(2), "my-2", 1, 2))
         tp.expectNext(EventEnvelope(Sequence(3), "my-3", 1, 3))
-        tp.expectNoMsg(NoMsgTime)
+        tp.expectNoMessage(NoMsgTime)
 
         actor1 ! withTags(1, "number")
         tp.expectNext(EventEnvelope(Sequence(4), "my-1", 2, 1))
@@ -125,7 +125,7 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config, con
         actor1 ! withTags(1, "number")
         tp.expectNext(EventEnvelope(Sequence(6), "my-1", 4, 1))
         tp.cancel()
-        tp.expectNoMsg(NoMsgTime)
+        tp.expectNoMessage(NoMsgTime)
       }
     }
   }
@@ -153,7 +153,7 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config, con
           map.updated(actorIdx, msgNumber + 1)
         }
         tp.cancel()
-        tp.expectNoMsg(NoMsgTime)
+        tp.expectNoMessage(NoMsgTime)
       }
     }
   }
@@ -172,12 +172,12 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config, con
         tp.request(Int.MaxValue)
         tp.expectNext(EventEnvelope(Sequence(2), "my-2", 1, 2))
         tp.expectNext(EventEnvelope(Sequence(3), "my-3", 1, 3))
-        tp.expectNoMsg(NoMsgTime)
+        tp.expectNoMessage(NoMsgTime)
 
         actor1 ! withTags(1, "number")
         tp.expectNext(EventEnvelope(Sequence(4), "my-1", 2, 1))
         tp.cancel()
-        tp.expectNoMsg(NoMsgTime)
+        tp.expectNoMessage(NoMsgTime)
       }
     }
   }
@@ -186,42 +186,42 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config, con
     withTestActors() { (actor1, actor2, actor3) =>
       withEventsByTag(10.seconds)("one", NoOffset) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNoMsg(NoMsgTime)
+        tp.expectNoMessage(NoMsgTime)
 
         actor1 ! withTags(1, "one") // 1
         tp.expectNext(EventEnvelope(Sequence(1), "my-1", 1, 1))
-        tp.expectNoMsg(NoMsgTime)
+        tp.expectNoMessage(NoMsgTime)
 
         actor2 ! withTags(1, "one") // 2
         tp.expectNext(EventEnvelope(Sequence(2), "my-2", 1, 1))
-        tp.expectNoMsg(NoMsgTime)
+        tp.expectNoMessage(NoMsgTime)
 
         actor3 ! withTags(1, "one") // 3
         tp.expectNext(EventEnvelope(Sequence(3), "my-3", 1, 1))
-        tp.expectNoMsg(NoMsgTime)
+        tp.expectNoMessage(NoMsgTime)
 
         actor1 ! withTags(2, "two") // 4
-        tp.expectNoMsg(NoMsgTime)
+        tp.expectNoMessage(NoMsgTime)
 
         actor2 ! withTags(2, "two") // 5
-        tp.expectNoMsg(NoMsgTime)
+        tp.expectNoMessage(NoMsgTime)
 
         actor3 ! withTags(2, "two") // 6
-        tp.expectNoMsg(NoMsgTime)
+        tp.expectNoMessage(NoMsgTime)
 
         actor1 ! withTags(1, "one") // 7
         tp.expectNext(EventEnvelope(Sequence(7), "my-1", 3, 1))
-        tp.expectNoMsg(NoMsgTime)
+        tp.expectNoMessage(NoMsgTime)
 
         actor2 ! withTags(1, "one") // 8
         tp.expectNext(EventEnvelope(Sequence(8), "my-2", 3, 1))
-        tp.expectNoMsg(NoMsgTime)
+        tp.expectNoMessage(NoMsgTime)
 
         actor3 ! withTags(1, "one") // 9
         tp.expectNext(EventEnvelope(Sequence(9), "my-3", 3, 1))
-        tp.expectNoMsg(NoMsgTime)
+        tp.expectNoMessage(NoMsgTime)
         tp.cancel()
-        tp.expectNoMsg(NoMsgTime)
+        tp.expectNoMessage(NoMsgTime)
       }
     }
   }
@@ -254,7 +254,7 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config, con
         tp.expectNext(EventEnvelope(Sequence(5), "my-1", 5, 5))
         tp.expectNext(EventEnvelope(Sequence(6), "my-2", 1, 3))
         tp.expectNext(EventEnvelope(Sequence(7), "my-3", 1, 3))
-        tp.expectNoMsg(NoMsgTime)
+        tp.expectNoMessage(NoMsgTime)
         tp.cancel()
       }
 
@@ -263,7 +263,7 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config, con
         tp.expectNext(EventEnvelope(Sequence(3), "my-1", 3, 3))
         tp.expectNext(EventEnvelope(Sequence(6), "my-2", 1, 3))
         tp.expectNext(EventEnvelope(Sequence(7), "my-3", 1, 3))
-        tp.expectNoMsg(NoMsgTime)
+        tp.expectNoMessage(NoMsgTime)
         tp.cancel()
       }
 
@@ -272,30 +272,30 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config, con
         tp.expectNext(EventEnvelope(Sequence(3), "my-1", 3, 3))
         tp.expectNext(EventEnvelope(Sequence(6), "my-2", 1, 3))
         tp.expectNext(EventEnvelope(Sequence(7), "my-3", 1, 3))
-        tp.expectNoMsg(NoMsgTime)
+        tp.expectNoMessage(NoMsgTime)
         tp.cancel()
       }
 
       withEventsByTag(10.seconds)("one", NoOffset) { tp =>
         tp.request(Int.MaxValue)
         tp.expectNext(EventEnvelope(Sequence(1), "my-1", 1, 1))
-        tp.expectNoMsg(NoMsgTime)
+        tp.expectNoMessage(NoMsgTime)
         tp.cancel()
       }
 
       withEventsByTag(10.seconds)("four", NoOffset) { tp =>
         tp.request(Int.MaxValue)
         tp.expectNextPF { case EventEnvelope(Sequence(4), "my-1", 4, 4) => }
-        tp.expectNoMsg(NoMsgTime)
+        tp.expectNoMessage(NoMsgTime)
         tp.cancel()
       }
 
       withEventsByTag(10.seconds)("five", NoOffset) { tp =>
         tp.request(Int.MaxValue)
         tp.expectNext(EventEnvelope(Sequence(5), "my-1", 5, 5))
-        tp.expectNoMsg(NoMsgTime)
+        tp.expectNoMessage(NoMsgTime)
         tp.cancel()
-        tp.expectNoMsg(NoMsgTime)
+        tp.expectNoMessage(NoMsgTime)
       }
     }
   }
@@ -322,7 +322,7 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config, con
           tp.request(Int.MaxValue)
           tp.expectNextN(150)
         }
-        tp.expectNoMsg(NoMsgTime)
+        tp.expectNoMessage(NoMsgTime)
 
         // Send a small batch of 3 * 5 messages
         sendMessagesWithTag(tag1, 5)
@@ -330,7 +330,7 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config, con
         tp.within(min = refreshInterval / 2, max = 2.seconds * timeoutMultiplier) {
           tp.expectNextN(15)
         }
-        tp.expectNoMsg(NoMsgTime)
+        tp.expectNoMessage(NoMsgTime)
 
         // another large batch should be retrieved fast
         // send a second batch of 3 * 100
@@ -339,7 +339,7 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config, con
           tp.request(Int.MaxValue)
           tp.expectNextN(300)
         }
-        tp.expectNoMsg(NoMsgTime)
+        tp.expectNoMessage(NoMsgTime)
       }
     }
   }

--- a/src/test/scala/akka/persistence/jdbc/query/JournalSequenceActorTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/JournalSequenceActorTest.scala
@@ -127,21 +127,21 @@ class MockDaoJournalSequenceActorTest extends SimpleSpec with MaterializerSpec {
       val firstBatch = (1L to 40L) ++ (51L to 110L)
       daoProbe.reply(firstBatch)
       withClue(s"when events are missing, the actor should wait for $queryDelay before querying again") {
-        daoProbe.expectNoMsg(almostQueryDelay)
+        daoProbe.expectNoMessage(almostQueryDelay)
         daoProbe.expectMsg(almostQueryDelay, TestProbeReadJournalDao.JournalSequence(40, batchSize))
       }
       // number 41 is still missing after this batch
       val secondBatch = 42L to 110L
       daoProbe.reply(secondBatch)
       withClue(s"when events are missing, the actor should wait for $queryDelay before querying again") {
-        daoProbe.expectNoMsg(almostQueryDelay)
+        daoProbe.expectNoMessage(almostQueryDelay)
         daoProbe.expectMsg(almostQueryDelay, TestProbeReadJournalDao.JournalSequence(40, batchSize))
       }
       val thirdBatch = 41L to 110L
       daoProbe.reply(thirdBatch)
       withClue(s"when no more events are missing, but less that batchSize elemens have been received, " +
         s"the actor should wait for $queryDelay before querying again") {
-        daoProbe.expectNoMsg(almostQueryDelay)
+        daoProbe.expectNoMessage(almostQueryDelay)
         daoProbe.expectMsg(almostQueryDelay, TestProbeReadJournalDao.JournalSequence(110, batchSize))
       }
 
@@ -154,7 +154,7 @@ class MockDaoJournalSequenceActorTest extends SimpleSpec with MaterializerSpec {
 
       // Reply to prevent a dead letter warning on the timeout
       daoProbe.reply(Seq.empty)
-      daoProbe.expectNoMsg(almostImmediately)
+      daoProbe.expectNoMessage(almostImmediately)
     }
   }
 
@@ -189,7 +189,7 @@ class MockDaoJournalSequenceActorTest extends SimpleSpec with MaterializerSpec {
 
       // Reply to prevent a dead letter warning on the timeout
       daoProbe.reply(Seq.empty)
-      daoProbe.expectNoMsg(almostImmediately)
+      daoProbe.expectNoMessage(almostImmediately)
     }
   }
 

--- a/src/test/scala/akka/persistence/jdbc/serialization/StoreOnlySerializableMessagesTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/serialization/StoreOnlySerializableMessagesTest.scala
@@ -67,16 +67,16 @@ abstract class StoreOnlySerializableMessagesTest(config: String, schemaType: Sch
       recover.expectMsg(RecoveryCompleted)
       tp.send(actor, "foo") // strings are serializable
       tp.expectMsg(akka.actor.Status.Success(""))
-      failure.expectNoMsg(100.millis)
-      rejected.expectNoMsg(100.millis)
+      failure.expectNoMessage(100.millis)
+      rejected.expectNoMessage(100.millis)
     }
 
     // the recover cycle
     withActor("1") { actor => recover => failure => rejected =>
       recover.expectMsg("foo")
       recover.expectMsg(RecoveryCompleted)
-      failure.expectNoMsg(100.millis)
-      rejected.expectNoMsg(100.millis)
+      failure.expectNoMessage(100.millis)
+      rejected.expectNoMessage(100.millis)
     }
   }
 
@@ -86,7 +86,7 @@ abstract class StoreOnlySerializableMessagesTest(config: String, schemaType: Sch
       val tp = TestProbe()
       recover.expectMsg(RecoveryCompleted)
       tp.send(actor, new NotSerializable) // the NotSerializable class cannot be serialized
-      tp.expectNoMsg(300.millis) // the handler should not have been called, because persist has failed
+      tp.expectNoMessage(300.millis) // the handler should not have been called, because persist has failed
       // the actor should call the OnPersistRejected
       rejected.expectMsgPF() {
         case PersistRejected(_, _, _) =>
@@ -96,7 +96,7 @@ abstract class StoreOnlySerializableMessagesTest(config: String, schemaType: Sch
     // the recover cycle, no message should be recovered
     withActor("2") { actor => recover => failure => rejected =>
       recover.expectMsg(RecoveryCompleted)
-      recover.expectNoMsg(100.millis)
+      recover.expectNoMessage(100.millis)
     }
   }
 
@@ -108,20 +108,20 @@ abstract class StoreOnlySerializableMessagesTest(config: String, schemaType: Sch
       tp.send(actor, "foo")
       tp.expectMsg(akka.actor.Status.Success(""))
       tp.send(actor, new NotSerializable) // the NotSerializable class cannot be serialized
-      tp.expectNoMsg(300.millis) // the handler should not have been called, because persist has failed
+      tp.expectNoMessage(300.millis) // the handler should not have been called, because persist has failed
       // the actor should call the OnPersistRejected
       rejected.expectMsgPF() {
         case PersistRejected(_, _, _) =>
       }
-      rejected.expectNoMsg(100.millis)
+      rejected.expectNoMessage(100.millis)
     }
 
     // recover cycle
     withActor("3") { actor => recover => failure => rejected =>
       recover.expectMsg("foo")
       recover.expectMsg(RecoveryCompleted)
-      failure.expectNoMsg(100.millis)
-      rejected.expectNoMsg(100.millis)
+      failure.expectNoMessage(100.millis)
+      rejected.expectNoMessage(100.millis)
     }
   }
 }


### PR DESCRIPTION
Made some improvements in the tests:

- One specific oracle tests now has a longer timeout, since it occasionaly failed on travis
- Global test timeout reduced from 40 minutes to 1 minute
- Resolved deprecation warnings in tests
- Enabled logging in tests, in order to do so, many dead letter warnings had to be resolved first