### PR TITLE
Set a name for the journal sequence actor

### DIFF
--- a/src/main/scala/akka/persistence/jdbc/query/scaladsl/JdbcReadJournal.scala
+++ b/src/main/scala/akka/persistence/jdbc/query/scaladsl/JdbcReadJournal.scala
@@ -92,7 +92,8 @@ class JdbcReadJournal(config: Config)(implicit val system: ExtendedActorSystem) 
   }
 
   // Started lazily to prevent the actor for querying the db if no eventsByTag queries are used
-  private[query] lazy val journalSequenceActor = system.actorOf(JournalSequenceActor.props(readJournalDao, readJournalConfig.journalSequenceRetrievalConfiguration))
+  private[query] lazy val journalSequenceActor = system.actorOf(
+    JournalSequenceActor.props(readJournalDao, readJournalConfig.journalSequenceRetrievalConfiguration), "akka-persistence-jdbc-journal-sequence-actor")
   private val delaySource =
     Source.tick(readJournalConfig.refreshInterval, 0.seconds, 0).take(1)
 


### PR DESCRIPTION
This ensures better logging in case of issues (e.g. dead letter warnings)