### PR TITLE
Dependency on JournalRow removed from readjournal

### DIFF
--- a/src/main/scala/akka/persistence/jdbc/journal/dao/ByteArrayJournalSerializer.scala
+++ b/src/main/scala/akka/persistence/jdbc/journal/dao/ByteArrayJournalSerializer.scala
@@ -38,8 +38,8 @@ class ByteArrayJournalSerializer(serialization: Serialization, separator: String
       ))
   }
 
-  override def deserialize(journalRow: JournalRow): Try[(PersistentRepr, Set[String], JournalRow)] = {
+  override def deserialize(journalRow: JournalRow): Try[(PersistentRepr, Set[String], Long)] = {
     serialization.deserialize(journalRow.message, classOf[PersistentRepr])
-      .map((_, decodeTags(journalRow.tags, separator), journalRow))
+      .map((_, decodeTags(journalRow.tags, separator), journalRow.ordering))
   }
 }

--- a/src/main/scala/akka/persistence/jdbc/query/dao/ByteArrayReadJournalDao.scala
+++ b/src/main/scala/akka/persistence/jdbc/query/dao/ByteArrayReadJournalDao.scala
@@ -45,7 +45,7 @@ trait BaseByteArrayReadJournalDao extends ReadJournalDao {
   override def allPersistenceIdsSource(max: Long): Source[String, NotUsed] =
     Source.fromPublisher(db.stream(queries.allPersistenceIdsDistinct(max).result))
 
-  override def eventsByTag(tag: String, offset: Long, maxOffset: Long, max: Long): Source[Try[(PersistentRepr, Set[String], JournalRow)], NotUsed] =
+  override def eventsByTag(tag: String, offset: Long, maxOffset: Long, max: Long): Source[Try[(PersistentRepr, Set[String], Long)], NotUsed] =
     Source.fromPublisher(db.stream(queries.eventsByTag(s"%$tag%", offset, maxOffset, max).result))
       .via(serializer.deserializeFlow)
 
@@ -92,7 +92,7 @@ trait OracleReadJournalDao extends ReadJournalDao {
 
   implicit val getJournalRow = GetResult(r => JournalRow(r.<<, r.<<, r.<<, r.<<, r.nextBytes(), r.<<))
 
-  abstract override def eventsByTag(tag: String, offset: Long, maxOffset: Long, max: Long): Source[Try[(PersistentRepr, Set[String], JournalRow)], NotUsed] = {
+  abstract override def eventsByTag(tag: String, offset: Long, maxOffset: Long, max: Long): Source[Try[(PersistentRepr, Set[String], Long)], NotUsed] = {
     if (isOracleDriver(profile)) {
       val theOffset = Math.max(0, offset)
       val theTag = s"%$tag%"
@@ -127,7 +127,7 @@ trait H2ReadJournalDao extends ReadJournalDao {
   abstract override def allPersistenceIdsSource(max: Long): Source[String, NotUsed] =
     super.allPersistenceIdsSource(correctMaxForH2Driver(max))
 
-  abstract override def eventsByTag(tag: String, offset: Long, maxOffset: Long, max: Long): Source[Try[(PersistentRepr, Set[String], JournalRow)], NotUsed] =
+  abstract override def eventsByTag(tag: String, offset: Long, maxOffset: Long, max: Long): Source[Try[(PersistentRepr, Set[String], Long)], NotUsed] =
     super.eventsByTag(tag, offset, maxOffset, correctMaxForH2Driver(max))
 
   abstract override def messages(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long): Source[Try[PersistentRepr], NotUsed] =

--- a/src/main/scala/akka/persistence/jdbc/query/dao/ReadJournalDao.scala
+++ b/src/main/scala/akka/persistence/jdbc/query/dao/ReadJournalDao.scala
@@ -32,10 +32,11 @@ trait ReadJournalDao {
   def allPersistenceIdsSource(max: Long): Source[String, NotUsed]
 
   /**
-   * Returns a Source of bytes for certain tag from an offset. The result is sorted by
-   * created time asc thus the offset is relative to the creation time
-   */
-  def eventsByTag(tag: String, offset: Long, maxOffset: Long, max: Long): Source[Try[(PersistentRepr, Set[String], JournalRow)], NotUsed]
+    * Returns a Source of deserialized data for certain tag from an offset. The result is sorted by
+    * the global ordering of the events.
+    * Each element with be a try with a PersistentRepr, set of tags, and a Long representing the global ordering of events
+    */
+  def eventsByTag(tag: String, offset: Long, maxOffset: Long, max: Long): Source[Try[(PersistentRepr, Set[String], Long)], NotUsed]
 
   /**
    * Returns a Source of bytes for a certain persistenceId

--- a/src/main/scala/akka/persistence/jdbc/query/scaladsl/JdbcReadJournal.scala
+++ b/src/main/scala/akka/persistence/jdbc/query/scaladsl/JdbcReadJournal.scala
@@ -157,8 +157,8 @@ class JdbcReadJournal(config: Config)(implicit val system: ExtendedActorSystem) 
       readJournalDao.eventsByTag(tag, offset, latestOrdering.maxOrdering, max)
         .mapAsync(1)(Future.fromTry)
         .mapConcat {
-          case (repr, _, row) =>
-            adaptEvents(repr).map(r => EventEnvelope(Sequence(row.ordering), r.persistenceId, r.sequenceNr, r.payload))
+          case (repr, _, ordering) =>
+            adaptEvents(repr).map(r => EventEnvelope(Sequence(ordering), r.persistenceId, r.sequenceNr, r.payload))
         }
     }
   }

--- a/src/main/scala/akka/persistence/jdbc/serialization/PersistentReprSerializer.scala
+++ b/src/main/scala/akka/persistence/jdbc/serialization/PersistentReprSerializer.scala
@@ -48,18 +48,25 @@ trait PersistentReprSerializer[T] {
 
   def serialize(persistentRepr: PersistentRepr, tags: Set[String]): Try[T]
 
-  def deserialize(t: T): Try[(PersistentRepr, Set[String], T)]
+  /**
+    * deserialize into a PersistentRepr, a set of tags and a Long representing the global ordering of events
+    */
+  def deserialize(t: T): Try[(PersistentRepr, Set[String], Long)]
 
 }
 
 trait FlowPersistentReprSerializer[T] extends PersistentReprSerializer[T] {
 
-  def deserializeFlow: Flow[T, Try[(PersistentRepr, Set[String], T)], NotUsed] = {
+  /**
+    * A flow which deserializes each element into a PersistentRepr,
+    * a set of tags and a Long representing the global ordering of events
+    */
+  def deserializeFlow: Flow[T, Try[(PersistentRepr, Set[String], Long)], NotUsed] = {
     Flow[T].map(deserialize)
   }
 
   def deserializeFlowWithoutTags: Flow[T, Try[PersistentRepr], NotUsed] = {
-    def keepPersistentRepr(tup: (PersistentRepr, Set[String], T)): PersistentRepr = tup match {
+    def keepPersistentRepr(tup: (PersistentRepr, Set[String], Long)): PersistentRepr = tup match {
       case (repr, _, _) => repr
     }
     deserializeFlow.map(_.map(keepPersistentRepr))

--- a/src/test/scala/akka/persistence/jdbc/query/dao/TestProbeReadJournalDao.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/dao/TestProbeReadJournalDao.scala
@@ -32,7 +32,7 @@ class TestProbeReadJournalDao(val probe: TestProbe) extends ReadJournalDao {
    * Returns a Source of bytes for certain tag from an offset. The result is sorted by
    * created time asc thus the offset is relative to the creation time
    */
-  override def eventsByTag(tag: String, offset: Long, maxOffset: Long, max: Long): Source[Try[(PersistentRepr, Set[String], jdbc.JournalRow)], NotUsed] = ???
+  override def eventsByTag(tag: String, offset: Long, maxOffset: Long, max: Long): Source[Try[(PersistentRepr, Set[String], Long)], NotUsed] = ???
 
   /**
    * Returns a Source of bytes for a certain persistenceId


### PR DESCRIPTION
Fixes #76 and #93 

Note this is a breaking change in the api of JdbcReadJournalDao, it should only affect those who actually implement their own read journal.