### PR TITLE
Allow for single database configuration

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -12,6 +12,100 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+akka-persistence-jdbc {
+
+  database-provider-fqcn = "akka.persistence.jdbc.util.DefaultSlickDatabaseProvider"
+
+  # (only used when database-provider-fqcn is set to the default "akka.persistence.jdbc.util.DefaultSlickDatabaseProvider")
+  # Automatically close the database connection using coordinated shutdown
+  shared-db-add-shutdown-hook = true
+  # The phase in which the database connection will be closed (used only if shared-db-add-shutdown-hook is enabled)
+  shared-db-coordinated-shutdown-phase = "before-actor-system-terminate"
+
+  shared-databases {
+    // Shared databases can be defined here.
+    // This reference config contains a partial example if a shared database which is enabled by configuring "slick" as the shared db
+    // this example is ignored by default as long as no profile is default
+    slick {
+
+      # This property indicates which profile must be used by Slick.
+      # Possible values are: slick.jdbc.PostgresProfile$, slick.jdbc.MySQLProfile$, slick.jdbc.H2Profile$ and slick.jdbc.OracleProfile$
+      # (uncomment and set the property below to match your needs)
+      # profile = "slick.jdbc.PostgresProfile$"
+
+      db {
+        connectionPool = "HikariCP"
+
+        # The JDBC URL for the chosen database
+        # (uncomment and set the property below to match your needs)
+        # url = "jdbc:postgresql://localhost:5432/akka-plugin"
+
+        # The database username
+        # (uncomment and set the property below to match your needs)
+        # user = "akka-plugin"
+
+        # The username's password
+        # (uncomment and set the property below to match your needs)
+        # password = "akka-plugin"
+
+        # The JDBC driver to use
+        # (uncomment and set the property below to match your needs)
+        # driver = "org.postgresql.Driver"
+
+        # hikariCP settings; see: https://github.com/brettwooldridge/HikariCP
+        # read: https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
+        # Slick will use an async executor with a fixed size queue of 10.000 objects
+        # The async executor is a connection pool for asynchronous execution of blocking I/O actions.
+        # This is used for the asynchronous query execution API on top of blocking back-ends like JDBC.
+        queueSize = 10000 // number of objects that can be queued by the async exector
+
+        # This property controls the maximum number of milliseconds that a client (that's you) will wait for a connection
+        # from the pool. If this time is exceeded without a connection becoming available, a SQLException will be thrown.
+        # 1000ms is the minimum value. Default: 180000 (3 minutes)
+        connectionTimeout = 180000
+
+        # This property controls the maximum amount of time that a connection will be tested for aliveness.
+        # This value must be less than the connectionTimeout. The lowest accepted validation timeout is 1000ms (1 second). Default: 5000
+        validationTimeout = 5000
+
+        # 10 minutes: This property controls the maximum amount of time that a connection is allowed to sit idle in the pool.
+        # Whether a connection is retired as idle or not is subject to a maximum variation of +30 seconds, and average variation
+        # of +15 seconds. A connection will never be retired as idle before this timeout. A value of 0 means that idle connections
+        # are never removed from the pool. Default: 600000 (10 minutes)
+        idleTimeout = 600000
+
+        # 30 minutes: This property controls the maximum lifetime of a connection in the pool. When a connection reaches this timeout
+        # it will be retired from the pool, subject to a maximum variation of +30 seconds. An in-use connection will never be retired,
+        # only when it is closed will it then be removed. We strongly recommend setting this value, and it should be at least 30 seconds
+        # less than any database-level connection timeout. A value of 0 indicates no maximum lifetime (infinite lifetime),
+        # subject of course to the idleTimeout setting. Default: 1800000 (30 minutes)
+        maxLifetime = 1800000
+
+        # This property controls the amount of time that a connection can be out of the pool before a message is logged indicating a
+        # possible connection leak. A value of 0 means leak detection is disabled.
+        # Lowest acceptable value for enabling leak detection is 2000 (2 secs). Default: 0
+        leakDetectionThreshold = 0
+
+        # This property controls whether the pool will "fail fast" if the pool cannot be seeded with initial connections successfully.
+        # If you want your application to start even when the database is down/unavailable, set this property to false. Default: true
+        initializationFailFast = false
+
+        # ensures that the database does not get dropped while we are using it
+        keepAliveConnection = on
+
+        # 5 * number of cores
+        numThreads = 20
+
+        # 5 * number of threads
+        maxConnections = 20
+
+        # number of threads
+        minConnections = 20
+      }
+    }
+  }
+}
+
 # the akka-persistence-journal in use
 jdbc-journal {
   class = "akka.persistence.jdbc.journal.JdbcAsyncWriteJournal"
@@ -46,6 +140,16 @@ jdbc-journal {
   parallelism = 8
   # Only mark as deleted. If false, delete physically
   logicalDelete = true
+
+  # This setting can be used to configure usage of a shared database.
+  # To disable usage of a shared database, set to null or an empty string.
+  # When set to a non emty string, this setting does two things:
+  # - The actor which manages the write-journal will not automatically close the db when the actor stops (since it is shared)
+  # - If akka-persistence-jdbc.database-provider-fqcn is set to akka.persistence.jdbc.util.DefaultSlickDatabaseProvider
+  #   then the shared database with the given name will be used. (shared databases are configured as part of akka-persistence-jdbc.shared-databases)
+  #   Please note that the database will only be shared with the other journals if the use-shared-db is also set
+  #   to the same value for these other journals.
+  use-shared-db = null
 
   slick {
     
@@ -142,6 +246,16 @@ jdbc-snapshot-store {
       }
     }
   }
+
+  # This setting can be used to configure usage of a shared database.
+  # To disable usage of a shared database, set to null or an empty string.
+  # When set to a non emty string, this setting does two things:
+  # - The actor which manages the snapshot-journal will not automatically close the db when the actor stops (since it is shared)
+  # - If akka-persistence-jdbc.database-provider-fqcn is set to akka.persistence.jdbc.util.DefaultSlickDatabaseProvider
+  #   then the shared database with the given name will be used. (shared databases are configured as part of akka-persistence-jdbc.shared-databases)
+  #   Please note that the database will only be shared with the other journals if the use-shared-db is also set
+  #   to the same value for these other journals.
+  use-shared-db = null
 
   dao = "akka.persistence.jdbc.snapshot.dao.ByteArraySnapshotDao"
 
@@ -240,8 +354,19 @@ jdbc-read-journal {
   # are delivered downstreams.
   max-buffer-size = "500"
 
-  # Automatically close the DB using addShutdownHook?
+  # Automatically close the database connection using Coordinated shutdown
   add-shutdown-hook = true
+  # The phase in which the database connection will be closed (used only if add-shutdown-hook is enabled)
+  coordinated-shutdown-phase = "before-actor-system-terminate"
+
+  # This setting can be used to configure usage of a shared database.
+  # To disable usage of a shared database, set to null or an empty string.
+  # This setting only has effect if akka-persistence-jdbc.database-provider-fqcn is set to
+  # akka.persistence.jdbc.util.DefaultSlickDatabaseProvider. When this setting is set to a non empty string
+  # then the shared database with the given name will be used. (shared databases are configured as part of akka-persistence-jdbc.shared-databases)
+  # Please note that the database will only be shared with the other journals if the use-shared-db is also set
+  # to the same value for these other journals.
+  use-shared-db = null
 
   dao = "akka.persistence.jdbc.query.dao.ByteArrayReadJournalDao"
 

--- a/src/main/scala/akka/persistence/jdbc/snapshot/JdbcSnapshotStore.scala
+++ b/src/main/scala/akka/persistence/jdbc/snapshot/JdbcSnapshotStore.scala
@@ -19,7 +19,7 @@ package akka.persistence.jdbc.snapshot
 import akka.actor.{ ActorSystem, ExtendedActorSystem }
 import akka.persistence.jdbc.config.SnapshotConfig
 import akka.persistence.jdbc.snapshot.dao.SnapshotDao
-import akka.persistence.jdbc.util.{ SlickDatabase, SlickDriver }
+import akka.persistence.jdbc.util.SlickExtension
 import akka.persistence.snapshot.SnapshotStore
 import akka.persistence.{ SelectedSnapshot, SnapshotMetadata, SnapshotSelectionCriteria }
 import akka.serialization.{ Serialization, SerializationExtension }
@@ -47,11 +47,12 @@ class JdbcSnapshotStore(config: Config) extends SnapshotStore {
   implicit val mat: Materializer = ActorMaterializer()
   val snapshotConfig = new SnapshotConfig(config)
 
-  val db: Database = SlickDatabase.forConfig(config, snapshotConfig.slickConfiguration)
+  val slickExtension = SlickExtension(system)
+  val db: Database = slickExtension.database(config)
 
   val snapshotDao: SnapshotDao = {
     val fqcn = snapshotConfig.pluginConfig.dao
-    val profile: JdbcProfile = SlickDriver.forDriverName(config)
+    val profile: JdbcProfile = slickExtension.profile(config)
     val args = Seq(
       (classOf[Database], db),
       (classOf[JdbcProfile], profile),
@@ -103,7 +104,10 @@ class JdbcSnapshotStore(config: Config) extends SnapshotStore {
   }
 
   override def postStop(): Unit = {
-    db.close()
+    if (snapshotConfig.useSharedDb.isEmpty) {
+      // Since a (new) db is created when this actor (re)starts, we must close it when the actor stops
+      db.close()
+    }
     super.postStop()
   }
 }

--- a/src/main/scala/akka/persistence/jdbc/util/ConfigOps.scala
+++ b/src/main/scala/akka/persistence/jdbc/util/ConfigOps.scala
@@ -42,6 +42,14 @@ object ConfigOps {
       Try(config.getInt(key))
         .getOrElse(default)
 
+    def asString(key: String, default: String): String =
+      Try(config.getString(key))
+        .getOrElse(default)
+
+    def asOptionalNonEmptyString(key: String): Option[String] = {
+      if (config.hasPath(key)) Some(config.getString(key)).filterNot(_.isEmpty) else None
+    }
+
     def asBoolean(key: String, default: Boolean) =
       Try(config.getBoolean(key))
         .getOrElse(default)

--- a/src/main/scala/akka/persistence/jdbc/util/SlickDriver.scala
+++ b/src/main/scala/akka/persistence/jdbc/util/SlickDriver.scala
@@ -25,14 +25,14 @@ import slick.jdbc.JdbcProfile
 import slick.jdbc.JdbcBackend._
 
 object SlickDriver {
-  def forDriverName(config: Config): JdbcProfile =
-    DatabaseConfig.forConfig[JdbcProfile]("slick", config).profile
+  def forDriverName(config: Config, path: String): JdbcProfile =
+    DatabaseConfig.forConfig[JdbcProfile](path, config).profile
 }
 
 object SlickDatabase {
-  def forConfig(config: Config, slickConfiguration: SlickConfiguration): Database = {
+  def forConfig(config: Config, slickConfiguration: SlickConfiguration, path: String): Database = {
     val jndiName = slickConfiguration.jndiName.map(Database.forName(_, None))
     val jndiDbName = slickConfiguration.jndiDbName.map(new InitialContext().lookup(_).asInstanceOf[Database])
-    jndiName.orElse(jndiDbName).getOrElse(Database.forConfig("slick.db", config))
+    jndiName.orElse(jndiDbName).getOrElse(Database.forConfig(path, config))
   }
 }

--- a/src/main/scala/akka/persistence/jdbc/util/SlickExtension.scala
+++ b/src/main/scala/akka/persistence/jdbc/util/SlickExtension.scala
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2016 Dennis Vriend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package akka.persistence.jdbc.util
+
+import akka.Done
+import akka.actor.{ActorSystem, CoordinatedShutdown, ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider}
+import akka.persistence.jdbc.config.{ConfigKeys, SlickConfiguration}
+import akka.persistence.jdbc.util.ConfigOps._
+import com.typesafe.config.{Config, ConfigObject}
+import slick.jdbc.JdbcBackend.Database
+import slick.jdbc.JdbcProfile
+
+import scala.collection.JavaConverters._
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
+
+object SlickExtension extends ExtensionId[SlickExtensionImpl] with ExtensionIdProvider {
+  override def lookup: SlickExtension.type = SlickExtension
+  override def createExtension(system: ExtendedActorSystem) = new SlickExtensionImpl(system)
+}
+
+class SlickExtensionImpl(system: ExtendedActorSystem) extends Extension {
+
+  private val dbProvider: SlickDatabaseProvider = {
+    val fqcn = system.settings.config.getString("akka-persistence-jdbc.database-provider-fqcn")
+    val args = List(classOf[ActorSystem] -> system)
+    system.dynamicAccess.createInstanceFor[SlickDatabaseProvider](fqcn, args) match {
+      case Success(result) => result
+      case Failure(t)      => throw new RuntimeException("Failed to create SlickDatabaseProvider", t)
+    }
+  }
+
+  def database(config: Config): Database = dbProvider.database(config)
+  def profile(config: Config): JdbcProfile = dbProvider.profile(config)
+}
+
+/**
+ * User overridable database provider.
+ * Since this provider is called from an akka extension it must be thread safe!
+ *
+ * A SlickDatabaseProvider is loaded using reflection,
+ * The instance is created using the following:
+ * - The fully qualified class name as configured in `jdbc-journal.database-provider-fqcn`.
+ * - The constructor with one argument of type [[akka.actor.ActorSystem]] is used to create the instance.
+ *   Therefore the class must have such a constructor.
+ */
+trait SlickDatabaseProvider {
+  /**
+   * Create or retrieve the database
+   * @param config The configuration which may be used to create the database. If the database is shared
+   *               then this parameter can be ignored.
+   */
+  def database(config: Config): Database
+  /**
+   * Create or retrieve the profile
+   * @param config The configuration which may be used to create the profile. If the database/profile is shared
+   *               then this parameter can be ignored.
+   */
+  def profile(config: Config): JdbcProfile
+}
+
+class DefaultSlickDatabaseProvider(system: ActorSystem) extends SlickDatabaseProvider {
+
+  val coordinatedShutdownPhaseOpt: Option[String] = if (system.settings.config.getBoolean("akka-persistence-jdbc.shared-db-add-shutdown-hook")) {
+    Some(system.settings.config.getString("akka-persistence-jdbc.shared-db-coordinated-shutdown-phase"))
+  } else None
+
+  val sharedDatabases: Map[String, DbHolder] = system.settings.config.getObject("akka-persistence-jdbc.shared-databases").asScala.flatMap {
+    case (key, confObj: ConfigObject) =>
+      val conf = confObj.toConfig
+      if (conf.hasPath("profile")) {
+        // Only create the DbHolder if a profile has actually been configured, this ensures that the example in the reference conf is ignored
+        Some(key -> new DbHolder(key, conf, coordinatedShutdownPhaseOpt, system))
+      } else None
+    case (key, notAnObject) => throw new RuntimeException(s"""Expected "akka-persistence-jdbc.shared-databases.$key" to be a config ConfigObject, but got ${notAnObject.valueType()} (${notAnObject.getClass})""")
+  }.toMap
+
+  private def getDbHolderOrThrow(sharedDbName: String): DbHolder =
+    sharedDatabases.getOrElse(
+      sharedDbName,
+      throw new RuntimeException(s"No shared database is configured under akka-persistence-jdbc.shared-databases.$sharedDbName")
+    )
+
+  def database(config: Config): Database = {
+    config.asOptionalNonEmptyString(ConfigKeys.useSharedDb) match {
+      case None => SlickDatabase.forConfig(config, new SlickConfiguration(config), "slick.db")
+      case Some(sharedDbName) =>
+        getDbHolderOrThrow(sharedDbName).db
+    }
+  }
+
+  def profile(config: Config): JdbcProfile = {
+    config.asOptionalNonEmptyString(ConfigKeys.useSharedDb) match {
+      case None => SlickDriver.forDriverName(config, "slick")
+      case Some(sharedDbName) =>
+        getDbHolderOrThrow(sharedDbName).profile
+    }
+  }
+}
+
+/**
+  * A DbHolder lazily initializes a database
+  * @param sharedDbName Name of the shared database (used as name of coordinated shutdown task)
+  * @param config The configuration used to create the database
+  * @param coordinatedShutdownPhaseOpt If defined, the database will be shutdown in this coordinated shutdown phase
+  */
+class DbHolder(sharedDbName: String, config: Config, coordinatedShutdownPhaseOpt: Option[String], system: ActorSystem) {
+  val profile: JdbcProfile = SlickDriver.forDriverName(config, path = "")
+
+  lazy val db: Database = {
+    implicit val ec: ExecutionContext = system.dispatcher
+    val db = SlickDatabase.forConfig(config, new SlickConfiguration(config), path = "db")
+    coordinatedShutdownPhaseOpt.foreach { phase =>
+      CoordinatedShutdown(system).addTask(phase, s"close-akka-persistence-jdbc-shared-db-$sharedDbName") { () =>
+        Future {
+          db.close()
+          Done
+        }
+      }
+    }
+    db
+  }
+}

--- a/src/test/resources/h2-shared-db-application.conf
+++ b/src/test/resources/h2-shared-db-application.conf
@@ -1,0 +1,62 @@
+# Copyright 2016 Dennis Vriend
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include "general.conf"
+
+akka {
+  persistence {
+    journal {
+      plugin = "jdbc-journal"
+      // Enable the line below to automatically start the journal when the actorsystem is started
+      // auto-start-journals = ["jdbc-journal"]
+    }
+    snapshot-store {
+      plugin = "jdbc-snapshot-store"
+      // Enable the line below to automatically start the snapshot-store when the actorsystem is started
+      // auto-start-snapshot-stores = ["jdbc-snapshot-store"]
+    }
+  }
+}
+
+akka-persistence-jdbc {
+  shared-databases {
+    slick {
+      profile = "slick.jdbc.H2Profile$"
+      db {
+        url = "jdbc:h2:mem:test-database;DATABASE_TO_UPPER=false;"
+        user = "root"
+        password = "root"
+        driver = "org.h2.Driver"
+        numThreads = 5
+        maxConnections = 5
+        minConnections = 1
+      }
+    }
+  }
+}
+
+jdbc-journal {
+  use-shared-db = "slick"
+}
+
+# the akka-persistence-snapshot-store in use
+jdbc-snapshot-store {
+  use-shared-db = "slick"
+}
+
+# the akka-persistence-query provider in use
+jdbc-read-journal {
+  use-shared-db = "slick"
+}
+

--- a/src/test/resources/mysql-shared-db-application.conf
+++ b/src/test/resources/mysql-shared-db-application.conf
@@ -1,0 +1,67 @@
+# Copyright 2016 Dennis Vriend
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include "general.conf"
+
+akka {
+  persistence {
+    journal {
+      plugin = "jdbc-journal"
+      // Enable the line below to automatically start the journal when the actorsystem is started
+      // auto-start-journals = ["jdbc-journal"]
+    }
+    snapshot-store {
+      plugin = "jdbc-snapshot-store"
+      // Enable the line below to automatically start the snapshot-store when the actorsystem is started
+      // auto-start-snapshot-stores = ["jdbc-snapshot-store"]
+    }
+  }
+}
+
+akka-persistence-jdbc {
+  shared-databases {
+    slick {
+      profile = "slick.jdbc.MySQLProfile$"
+      db {
+        host = ${docker.host}
+        host = ${?MYSQL_HOST}
+        port = "3306"
+        port = ${?MYSQL_PORT}
+        url = "jdbc:mysql://"${akka-persistence-jdbc.shared-databases.slick.db.host}":"${akka-persistence-jdbc.shared-databases.slick.db.port}"/mysql?cachePrepStmts=true&cacheCallableStmts=true&cacheServerConfiguration=true&useLocalSessionState=true&elideSetAutoCommits=true&alwaysSendSetIsolation=false&enableQueryTimeouts=false&connectionAttributes=none&verifyServerCertificate=false&useSSL=false&useUnicode=true&useLegacyDatetimeCode=false&serverTimezone=UTC&rewriteBatchedStatements=true"
+        user = "root"
+        user = ${?MYSQL_USER}
+        password = "root"
+        password = ${?MYSQL_PASSWORD}
+        driver = "com.mysql.cj.jdbc.Driver"
+        numThreads = 5
+        maxConnections = 5
+        minConnections = 1
+      }
+    }
+  }
+}
+
+jdbc-journal {
+  use-shared-db = "slick"
+}
+
+# the akka-persistence-snapshot-store in use
+jdbc-snapshot-store {
+  use-shared-db = "slick"
+}
+
+# the akka-persistence-query provider in use
+jdbc-read-journal {
+  use-shared-db = "slick"
+}

--- a/src/test/resources/oracle-shared-db-application.conf
+++ b/src/test/resources/oracle-shared-db-application.conf
@@ -1,0 +1,65 @@
+# Copyright 2016 Dennis Vriend
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include "general.conf"
+
+akka {
+  persistence {
+    journal {
+      plugin = "jdbc-journal"
+      // Enable the line below to automatically start the journal when the actorsystem is started
+      // auto-start-journals = ["jdbc-journal"]
+    }
+    snapshot-store {
+      plugin = "jdbc-snapshot-store"
+      // Enable the line below to automatically start the snapshot-store when the actorsystem is started
+      // auto-start-snapshot-stores = ["jdbc-snapshot-store"]
+    }
+  }
+}
+
+akka-persistence-jdbc {
+  shared-databases {
+    slick {
+      profile = "slick.jdbc.OracleProfile$"
+      db {
+        host = ${docker.host}
+        host = ${?ORACLE_HOST}
+        url = "jdbc:oracle:thin:@//"${akka-persistence-jdbc.shared-databases.slick.db.host}":1521/xe"
+        user = "system"
+        user = ${?ORACLE_USER}
+        password = "oracle"
+        password = ${?ORACLE_PASSWORD}
+        driver = "oracle.jdbc.OracleDriver"
+        numThreads = 5
+        maxConnections = 5
+        minConnections = 1
+      }
+    }
+  }
+}
+
+jdbc-journal {
+  use-shared-db = "slick"
+}
+
+# the akka-persistence-snapshot-store in use
+jdbc-snapshot-store {
+  use-shared-db = "slick"
+}
+
+# the akka-persistence-query provider in use
+jdbc-read-journal {
+  use-shared-db = "slick"
+}

--- a/src/test/resources/postgres-shared-db-application.conf
+++ b/src/test/resources/postgres-shared-db-application.conf
@@ -1,0 +1,65 @@
+# Copyright 2016 Dennis Vriend
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include "general.conf"
+
+akka {
+  persistence {
+    journal {
+      plugin = "jdbc-journal"
+      // Enable the line below to automatically start the journal when the actorsystem is started
+      // auto-start-journals = ["jdbc-journal"]
+    }
+    snapshot-store {
+      plugin = "jdbc-snapshot-store"
+      // Enable the line below to automatically start the snapshot-store when the actorsystem is started
+      // auto-start-snapshot-stores = ["jdbc-snapshot-store"]
+    }
+  }
+}
+
+akka-persistence-jdbc {
+  shared-databases {
+    slick {
+      profile = "slick.jdbc.PostgresProfile$"
+      db {
+        host = "localhost"
+        host = ${?POSTGRES_HOST}
+        url = "jdbc:postgresql://"${akka-persistence-jdbc.shared-databases.slick.db.host}":5432/docker?reWriteBatchedInserts=true"
+        user = "docker"
+        user = ${?POSTGRES_USER}
+        password = "docker"
+        password = ${?POSTGRES_PASSWORD}
+        driver = "org.postgresql.Driver"
+        numThreads = 5
+        maxConnections = 5
+        minConnections = 1
+      }
+    }
+  }
+}
+
+jdbc-journal {
+  use-shared-db = "slick"
+}
+
+# the akka-persistence-snapshot-store in use
+jdbc-snapshot-store {
+  use-shared-db = "slick"
+}
+
+# the akka-persistence-query provider in use
+jdbc-read-journal {
+  use-shared-db = "slick"
+}

--- a/src/test/scala/akka/persistence/jdbc/journal/JdbcJournalSpec.scala
+++ b/src/test/scala/akka/persistence/jdbc/journal/JdbcJournalSpec.scala
@@ -19,11 +19,11 @@ package akka.persistence.jdbc.journal
 import akka.persistence.CapabilityFlag
 import akka.persistence.jdbc.config._
 import akka.persistence.jdbc.util.Schema._
-import akka.persistence.jdbc.util.{ ClasspathResources, DropCreate, SlickDatabase }
+import akka.persistence.jdbc.util.{ClasspathResources, DropCreate, SlickDatabase, SlickExtension}
 import akka.persistence.journal.JournalSpec
-import com.typesafe.config.{ Config, ConfigFactory, ConfigValueFactory }
+import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach }
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 
 import scala.concurrent.duration._
 
@@ -44,7 +44,7 @@ abstract class JdbcJournalSpec(config: Config, schemaType: SchemaType) extends J
 
   lazy val journalConfig = new JournalConfig(cfg)
 
-  lazy val db = SlickDatabase.forConfig(cfg, journalConfig.slickConfiguration)
+  lazy val db = SlickExtension(system).database(cfg)
 
   override def beforeAll(): Unit = {
     dropCreate(schemaType)
@@ -57,26 +57,21 @@ abstract class JdbcJournalSpec(config: Config, schemaType: SchemaType) extends J
   }
 }
 
-/**
- * Use the postgres DDL script that is available on the website, for some reason slick generates incorrect DDL,
- * but the Slick Tables definition must not change, else it breaks the UPSERT feature...
- */
 class PostgresJournalSpec extends JdbcJournalSpec(ConfigFactory.load("postgres-application.conf"), Postgres())
+class PostgresJournalSpecSharedDb extends JdbcJournalSpec(ConfigFactory.load("postgres-shared-db-application.conf"), Postgres())
 class PostgresJournalSpecPhysicalDelete extends JdbcJournalSpec(ConfigFactory.load("postgres-application.conf")
   .withValue("jdbc-journal.logicalDelete", ConfigValueFactory.fromAnyRef(false)), Postgres())
 
-/**
- * Does not (yet) work because Slick generates double quotes to escape field names
- * for some reason when creating the DDL
- */
-class MySQLJournalSpec extends JdbcJournalSpec(ConfigFactory.load("mysql-application.conf"), MySQL())
+class MySQLJournalSpecSharedDb extends JdbcJournalSpec(ConfigFactory.load("mysql-shared-db-application.conf"), MySQL())
 class MySQLJournalSpecPhysicalDelete extends JdbcJournalSpec(ConfigFactory.load("mysql-application.conf")
   .withValue("jdbc-journal.logicalDelete", ConfigValueFactory.fromAnyRef(false)), MySQL())
 
 class OracleJournalSpec extends JdbcJournalSpec(ConfigFactory.load("oracle-application.conf"), Oracle())
+class OracleJournalSpecSharedDb extends JdbcJournalSpec(ConfigFactory.load("oracle-shared-db-application.conf"), Oracle())
 class OracleJournalSpecPhysicalDelete extends JdbcJournalSpec(ConfigFactory.load("oracle-application.conf")
   .withValue("jdbc-journal.logicalDelete", ConfigValueFactory.fromAnyRef(false)), Oracle())
 
 class H2JournalSpec extends JdbcJournalSpec(ConfigFactory.load("h2-application.conf"), H2())
+class H2JournalSpecSharedDb extends JdbcJournalSpec(ConfigFactory.load("h2-shared-db-application.conf"), H2())
 class H2JournalSpecPhysicalDelete extends JdbcJournalSpec(ConfigFactory.load("h2-application.conf")
   .withValue("jdbc-journal.logicalDelete", ConfigValueFactory.fromAnyRef(false)), H2())

--- a/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByPersistenceIdTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByPersistenceIdTest.scala
@@ -135,10 +135,12 @@ abstract class CurrentEventsByPersistenceIdTest(config: String) extends QueryTes
   }
 }
 
-class PostgresScalaCurrentEventsByPersistenceIdTest extends CurrentEventsByPersistenceIdTest("postgres-application.conf") with PostgresCleaner
+// Note: these tests use the shared-db configs, the test for all (so not only current) events use the regular db config
 
-class MySQLScalaCurrentEventsByPersistenceIdTest extends CurrentEventsByPersistenceIdTest("mysql-application.conf") with MysqlCleaner
+class PostgresScalaCurrentEventsByPersistenceIdTest extends CurrentEventsByPersistenceIdTest("postgres-shared-db-application.conf") with PostgresCleaner
 
-class OracleScalaCurrentEventsByPersistenceIdTest extends CurrentEventsByPersistenceIdTest("oracle-application.conf") with OracleCleaner
+class MySQLScalaCurrentEventsByPersistenceIdTest extends CurrentEventsByPersistenceIdTest("mysql-shared-db-application.conf") with MysqlCleaner
 
-class H2ScalaCurrentEventsByPersistenceIdTest extends CurrentEventsByPersistenceIdTest("h2-application.conf") with H2Cleaner
+class OracleScalaCurrentEventsByPersistenceIdTest extends CurrentEventsByPersistenceIdTest("oracle-shared-db-application.conf") with OracleCleaner
+
+class H2ScalaCurrentEventsByPersistenceIdTest extends CurrentEventsByPersistenceIdTest("h2-shared-db-application.conf") with H2Cleaner

--- a/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByTagTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByTagTest.scala
@@ -211,10 +211,12 @@ abstract class CurrentEventsByTagTest(config: String) extends QueryTestSpec(conf
   }
 }
 
-class PostgresScalaCurrentEventsByTagTest extends CurrentEventsByTagTest("postgres-application.conf") with PostgresCleaner
+// Note: these tests use the shared-db configs, the test for all (so not only current) events use the regular db config
 
-class MySQLScalaCurrentEventsByTagTest extends CurrentEventsByTagTest("mysql-application.conf") with MysqlCleaner
+class PostgresScalaCurrentEventsByTagTest extends CurrentEventsByTagTest("postgres-shared-db-application.conf") with PostgresCleaner
 
-class OracleScalaCurrentEventsByTagTest extends CurrentEventsByTagTest("oracle-application.conf") with OracleCleaner
+class MySQLScalaCurrentEventsByTagTest extends CurrentEventsByTagTest("mysql-shared-db-application.conf") with MysqlCleaner
 
-class H2ScalaCurrentEventsByTagTest extends CurrentEventsByTagTest("h2-application.conf") with H2Cleaner
+class OracleScalaCurrentEventsByTagTest extends CurrentEventsByTagTest("oracle-shared-db-application.conf") with OracleCleaner
+
+class H2ScalaCurrentEventsByTagTest extends CurrentEventsByTagTest("h2-shared-db-application.conf") with H2Cleaner

--- a/src/test/scala/akka/persistence/jdbc/query/CurrentPersistenceIdsTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/CurrentPersistenceIdsTest.scala
@@ -44,10 +44,12 @@ abstract class CurrentPersistenceIdsTest(config: String) extends QueryTestSpec(c
   }
 }
 
-class PostgresScalaCurrentPersistenceIdsTest extends CurrentPersistenceIdsTest("postgres-application.conf") with PostgresCleaner
+// Note: these tests use the shared-db configs, the test for all persistence ids use the regular db config
 
-class MySQLScalaCurrentPersistenceIdsTest extends CurrentPersistenceIdsTest("mysql-application.conf") with MysqlCleaner
+class PostgresScalaCurrentPersistenceIdsTest extends CurrentPersistenceIdsTest("postgres-shared-db-application.conf") with PostgresCleaner
 
-class OracleScalaCurrentPersistenceIdsTest extends CurrentPersistenceIdsTest("oracle-application.conf") with OracleCleaner
+class MySQLScalaCurrentPersistenceIdsTest extends CurrentPersistenceIdsTest("mysql-shared-db-application.conf") with MysqlCleaner
 
-class H2ScalaCurrentPersistenceIdsTest extends CurrentPersistenceIdsTest("h2-application.conf") with H2Cleaner
+class OracleScalaCurrentPersistenceIdsTest extends CurrentPersistenceIdsTest("oracle-shared-db-application.conf") with OracleCleaner
+
+class H2ScalaCurrentPersistenceIdsTest extends CurrentPersistenceIdsTest("h2-shared-db-application.conf") with H2Cleaner

--- a/src/test/scala/akka/persistence/jdbc/query/QueryTestSpec.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/QueryTestSpec.scala
@@ -215,7 +215,7 @@ trait PostgresCleaner extends QueryTestSpec {
       sqlu"""TRUNCATE snapshot""").transactionally
 
   def clearPostgres(): Unit =
-    withDatabase(_.run(actionsClearPostgres).toTry) should be a 'success
+    withDatabase(_.run(actionsClearPostgres).futureValue)
 
   override def beforeAll(): Unit = {
     dropCreate(Postgres())
@@ -237,7 +237,7 @@ trait MysqlCleaner extends QueryTestSpec {
       sqlu"""TRUNCATE snapshot""").transactionally
 
   def clearMySQL(): Unit =
-    withDatabase(_.run(actionsClearMySQL).toTry) should be a 'success
+    withDatabase(_.run(actionsClearMySQL).futureValue)
 
   override def beforeAll(): Unit = {
     dropCreate(MySQL())
@@ -260,7 +260,7 @@ trait OracleCleaner extends QueryTestSpec {
       sqlu"""BEGIN "reset_sequence"; END; """).transactionally
 
   def clearOracle(): Unit =
-    withDatabase(_.run(actionsClearOracle).toTry) should be a 'success
+    withDatabase(_.run(actionsClearOracle).futureValue)
 
   override def beforeAll(): Unit = {
     dropCreate(Oracle())
@@ -282,7 +282,7 @@ trait H2Cleaner extends QueryTestSpec {
       sqlu"""TRUNCATE TABLE snapshot""").transactionally
 
   def clearH2(): Unit =
-    withDatabase(_.run(actionsClearH2).toTry) should be a 'success
+    withDatabase(_.run(actionsClearH2).futureValue)
 
   override def beforeEach(): Unit = {
     dropCreate(H2())

--- a/src/test/scala/akka/persistence/jdbc/snapshot/JdbcSnapshotStoreSpec.scala
+++ b/src/test/scala/akka/persistence/jdbc/snapshot/JdbcSnapshotStoreSpec.scala
@@ -36,7 +36,7 @@ abstract class JdbcSnapshotStoreSpec(config: Config, schemaType: SchemaType) ext
 
   lazy val journalConfig = new JournalConfig(cfg)
 
-  lazy val db = SlickDatabase.forConfig(cfg, journalConfig.slickConfiguration)
+  lazy val db = SlickDatabase.forConfig(cfg, journalConfig.slickConfiguration, "slick.db")
 
   override def beforeAll(): Unit = {
     dropCreate(schemaType)


### PR DESCRIPTION
This PR enables more flexibility in the database configuration.

The goals of this change are the following:

- *Backwards combatibility*: Existing configurations should work as before
- *Flexibility*: It should be possible to provide a custom provider for a database, allowing any possible configuration.
- *Single db for all journals*: It should be easy to configure one single database which is used for all journals.