### PR TITLE
Added scaladoc to the eventsByTag queries

### DIFF
--- a/src/main/scala/akka/persistence/jdbc/query/javadsl/JdbcReadJournal.scala
+++ b/src/main/scala/akka/persistence/jdbc/query/javadsl/JdbcReadJournal.scala
@@ -46,9 +46,41 @@ class JdbcReadJournal(journal: ScalaJdbcReadJournal) extends ReadJournal
   override def eventsByPersistenceId(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long): Source[EventEnvelope, NotUsed] =
     journal.eventsByPersistenceId(persistenceId, fromSequenceNr, toSequenceNr).asJava
 
+  /**
+    * Same type of query as [[EventsByTagQuery#eventsByTag]] but the event stream
+    * is completed immediately when it reaches the end of the "result set". Events that are
+    * stored after the query is completed are not included in the event stream.
+    *
+    * akka-persistence-jdbc has implemented this feature by using a LIKE %tag% query on the tags column.
+    * A consequence of this is that tag names must be chosen wisely: for example when querying the tag `User`,
+    * events with the tag `UserEmail` will also be returned (since User is a substring of UserEmail).
+    *
+    * The returned event stream is ordered by `offset`.
+    */
   override def currentEventsByTag(tag: String, offset: Offset): Source[EventEnvelope, NotUsed] =
     journal.currentEventsByTag(tag, offset).asJava
 
+  /**
+    * Query events that have a specific tag.
+    *
+    * akka-persistence-jdbc has implemented this feature by using a LIKE %tag% query on the tags column.
+    * A consequence of this is that tag names must be chosen wisely: for example when querying the tag `User`,
+    * events with the tag `UserEmail` will also be returned (since User is a substring of UserEmail).
+    *
+    * The consumer can keep track of its current position in the event stream by storing the
+    * `offset` and restart the query from a given `offset` after a crash/restart.
+    *
+    * For akka-persistence-jdbc the `offset` corresponds to the `ordering` column in the Journal table.
+    * The `ordering` is a sequential id number that uniquely identifies the position of each event within
+    * the event stream.
+    *
+    * The returned event stream is ordered by `offset`.
+    *
+    * The stream is not completed when it reaches the end of the currently stored events,
+    * but it continues to push new events when new events are persisted.
+    * Corresponding query that is completed when it reaches the end of the currently
+    * stored events is provided by [[CurrentEventsByTagQuery#currentEventsByTag]].
+    */
   override def eventsByTag(tag: String, offset: Offset): Source[EventEnvelope, NotUsed] =
     journal.eventsByTag(tag, offset).asJava
 }

--- a/src/main/scala/akka/persistence/jdbc/query/scaladsl/JdbcReadJournal.scala
+++ b/src/main/scala/akka/persistence/jdbc/query/scaladsl/JdbcReadJournal.scala
@@ -150,6 +150,17 @@ class JdbcReadJournal(config: Config)(implicit val system: ExtendedActorSystem) 
       }
     }.mapConcat(identity)
 
+  /**
+    * Same type of query as [[EventsByTagQuery#eventsByTag]] but the event stream
+    * is completed immediately when it reaches the end of the "result set". Events that are
+    * stored after the query is completed are not included in the event stream.
+    *
+    * akka-persistence-jdbc has implemented this feature by using a LIKE %tag% query on the tags column.
+    * A consequence of this is that tag names must be chosen wisely: for example when querying the tag `User`,
+    * events with the tag `UserEmail` will also be returned (since User is a substring of UserEmail).
+    *
+    * The returned event stream is ordered by `offset`.
+    */
   override def currentEventsByTag(tag: String, offset: Offset): Source[EventEnvelope, NotUsed] =
     currentEventsByTag(tag, offset.value)
 
@@ -220,6 +231,27 @@ class JdbcReadJournal(config: Config)(implicit val system: ExtendedActorSystem) 
         eventsByTag(tag, offset, terminateAfterOffset = Some(maxOrderingInDb))
       }
 
+  /**
+    * Query events that have a specific tag.
+    *
+    * akka-persistence-jdbc has implemented this feature by using a LIKE %tag% query on the tags column.
+    * A consequence of this is that tag names must be chosen wisely: for example when querying the tag `User`,
+    * events with the tag `UserEmail` will also be returned (since User is a substring of UserEmail).
+    *
+    * The consumer can keep track of its current position in the event stream by storing the
+    * `offset` and restart the query from a given `offset` after a crash/restart.
+    *
+    * For akka-persistence-jdbc the `offset` corresponds to the `ordering` column in the Journal table.
+    * The `ordering` is a sequential id number that uniquely identifies the position of each event within
+    * the event stream.
+    *
+    * The returned event stream is ordered by `offset`.
+    *
+    * The stream is not completed when it reaches the end of the currently stored events,
+    * but it continues to push new events when new events are persisted.
+    * Corresponding query that is completed when it reaches the end of the currently
+    * stored events is provided by [[CurrentEventsByTagQuery#currentEventsByTag]].
+    */
   override def eventsByTag(tag: String, offset: Offset): Source[EventEnvelope, NotUsed] =
     eventsByTag(tag, offset.value)
 


### PR DESCRIPTION
Added documentation for the eventsByTag an currentEventsByTag queries.

Specifically the documentation describes the meaning of the `offset` in our plugin, it states that the streams are ordered by `offset`. And that the query is implemented using a LIKE query.

Adding this documentation fixes #82. Because this information is needed for users to be able to work around the tag substring issue as described in #82. (Now that we have documented this, we can consider this a feature instead of a bug 😉)

The actual content of the docs has been based on what is originally described in the scaladoc of the akka traits for [CurrentEventsByTagQuery](https://github.com/akka/akka/blob/master/akka-persistence-query/src/main/scala/akka/persistence/query/scaladsl/CurrentEventsByTagQuery.scala) and [EventsByTagQuery](https://github.com/akka/akka/blob/master/akka-persistence-query/src/main/scala/akka/persistence/query/scaladsl/EventsByTagQuery.scala).

The other persistence-queries do not need any additional documentation, since the documentation provided by the (inherited) akka scaladoc is already sufficient.