### PR TITLE
Actor name should be unique in case of multiple read journals

### DIFF
--- a/src/main/scala/akka/persistence/jdbc/query/JdbcReadJournalProvider.scala
+++ b/src/main/scala/akka/persistence/jdbc/query/JdbcReadJournalProvider.scala
@@ -20,8 +20,8 @@ import akka.actor.ExtendedActorSystem
 import akka.persistence.query.ReadJournalProvider
 import com.typesafe.config.Config
 
-class JdbcReadJournalProvider(system: ExtendedActorSystem, config: Config) extends ReadJournalProvider {
-  override val scaladslReadJournal = new scaladsl.JdbcReadJournal(config)(system)
+class JdbcReadJournalProvider(system: ExtendedActorSystem, config: Config, configPath: String) extends ReadJournalProvider {
+  override val scaladslReadJournal = new scaladsl.JdbcReadJournal(config, configPath)(system)
 
   override val javadslReadJournal = new javadsl.JdbcReadJournal(scaladslReadJournal)
 }

--- a/src/main/scala/akka/persistence/jdbc/query/scaladsl/JdbcReadJournal.scala
+++ b/src/main/scala/akka/persistence/jdbc/query/scaladsl/JdbcReadJournal.scala
@@ -57,7 +57,7 @@ object JdbcReadJournal {
   private case object Stop extends FlowControl
 }
 
-class JdbcReadJournal(config: Config)(implicit val system: ExtendedActorSystem) extends ReadJournal
+class JdbcReadJournal(config: Config, configPath: String)(implicit val system: ExtendedActorSystem) extends ReadJournal
   with CurrentPersistenceIdsQuery
   with PersistenceIdsQuery
   with CurrentEventsByPersistenceIdQuery
@@ -94,7 +94,7 @@ class JdbcReadJournal(config: Config)(implicit val system: ExtendedActorSystem) 
   // Started lazily to prevent the actor for querying the db if no eventsByTag queries are used
   private[query] lazy val journalSequenceActor = system.actorOf(
     JournalSequenceActor.props(readJournalDao, readJournalConfig.journalSequenceRetrievalConfiguration),
-    "akka-persistence-jdbc-journal-sequence-actor")
+    s"$configPath.akka-persistence-jdbc-journal-sequence-actor")
   private val delaySource =
     Source.tick(readJournalConfig.refreshInterval, 0.seconds, 0).take(1)
 

--- a/src/test/resources/h2-two-read-journals-application.conf
+++ b/src/test/resources/h2-two-read-journals-application.conf
@@ -1,0 +1,75 @@
+# Copyright 2016 Dennis Vriend
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include "general.conf"
+
+jdbc-journal {
+  slick = ${slick}
+  slick.db.numThreads = 20
+  slick.db.maxConnections = 100
+  slick.db.minConnections = 1
+  slick.db.connectionTimeout = 1800000 // 30 minutes
+
+  event-adapters {
+    test-write-event-adapter = "akka.persistence.jdbc.query.EventAdapterTest$TestWriteEventAdapter"
+    test-read-event-adapter  = "akka.persistence.jdbc.query.EventAdapterTest$TestReadEventAdapter"
+  }
+
+  event-adapter-bindings {
+    "akka.persistence.jdbc.query.EventAdapterTest$Event"            = test-write-event-adapter
+    "akka.persistence.jdbc.query.EventAdapterTest$TaggedEvent"      = test-write-event-adapter
+    "akka.persistence.jdbc.query.EventAdapterTest$TaggedAsyncEvent" = test-write-event-adapter
+    "akka.persistence.jdbc.query.EventAdapterTest$EventAdapted"     = test-read-event-adapter
+  }
+
+}
+
+# the akka-persistence-snapshot-store in use
+jdbc-snapshot-store {
+  slick = ${slick}
+  slick.db.numThreads = 20
+  slick.db.maxConnections = 100
+  slick.db.minConnections = 1
+  slick.db.connectionTimeout = 1800000 // 30 minutes
+}
+
+# the akka-persistence-query provider in use
+jdbc-read-journal {
+  refresh-interval = "10ms"
+
+  max-buffer-size = "500"
+
+  add-shutdown-hook = true
+
+  slick = ${slick}
+  slick.db.numThreads = 20
+  slick.db.maxConnections = 100
+  slick.db.minConnections = 1
+  slick.db.connectionTimeout = 1800000 // 30 minutes
+}
+
+// In this case we use exactly the same config for the second journal
+// (this includes the defaults form reference.conf)
+jdbc-read-journal-number-two = ${jdbc-read-journal}
+
+slick {
+  profile = "slick.jdbc.H2Profile$"
+  db {
+    url = "jdbc:h2:mem:test-database;DATABASE_TO_UPPER=false;"
+    user = "root"
+    password = "root"
+    driver = "org.h2.Driver"
+    connectionTestQuery = "SELECT 1"
+  }
+}

--- a/src/test/scala/akka/persistence/jdbc/query/MultipleReadJournalTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/MultipleReadJournalTest.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016 Dennis Vriend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package akka.persistence.jdbc.query
+
+import akka.persistence.jdbc.query.EventsByTagTest._
+import akka.persistence.jdbc.query.scaladsl.JdbcReadJournal
+import akka.persistence.query.{ NoOffset, PersistenceQuery }
+import akka.stream.{ ActorMaterializer, Materializer }
+import akka.stream.scaladsl.Sink
+
+class MultipleReadJournalTest extends QueryTestSpec("h2-two-read-journals-application.conf", configOverrides) with H2Cleaner {
+
+  it should "be able to create two read journals and use eventsByTag on them" in withActorSystem { implicit system =>
+    implicit val mat: Materializer = ActorMaterializer()
+    val normalReadJournal = PersistenceQuery(system).readJournalFor[JdbcReadJournal](JdbcReadJournal.Identifier)
+    val secondReadJournal = PersistenceQuery(system).readJournalFor[JdbcReadJournal]("jdbc-read-journal-number-two")
+
+    val events1 = normalReadJournal.currentEventsByTag("someTag", NoOffset).runWith(Sink.seq)
+    val events2 = secondReadJournal.currentEventsByTag("someTag", NoOffset).runWith(Sink.seq)
+    events1.futureValue shouldBe empty
+    events2.futureValue shouldBe empty
+  }
+}


### PR DESCRIPTION
Ensure that the journal sequence actor name is unique when multiple read journals are used.

fixes #169

Thanks to @TimMoore for logging the issue with a good idea on how to fix this!