### PR TITLE
Aligned numThreads and maxConnections in the config

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -118,7 +118,7 @@ jdbc-journal {
       numThreads = 20
 
       # 5 * number of threads
-      maxConnections = 100
+      maxConnections = 20
 
       # number of threads
       minConnections = 20
@@ -216,7 +216,7 @@ jdbc-snapshot-store {
       numThreads = 20
 
       # 5 * number of threads
-      maxConnections = 100
+      maxConnections = 20
 
       # number of threads
       minConnections = 20
@@ -350,8 +350,8 @@ jdbc-read-journal {
       # 5 * number of cores
       numThreads = 20
 
-      # 5 * number of threads
-      maxConnections = 100
+      # number of threads
+      maxConnections = 20
 
       # number of threads
       minConnections = 20

--- a/src/test/resources/h2-application.conf
+++ b/src/test/resources/h2-application.conf
@@ -17,7 +17,7 @@ include "general.conf"
 jdbc-journal {
   slick = ${slick}
   slick.db.numThreads = 20
-  slick.db.maxConnections = 100
+  slick.db.maxConnections = 20
   slick.db.minConnections = 1
   slick.db.connectionTimeout = 1800000 // 30 minutes
 
@@ -39,7 +39,7 @@ jdbc-journal {
 jdbc-snapshot-store {
   slick = ${slick}
   slick.db.numThreads = 20
-  slick.db.maxConnections = 100
+  slick.db.maxConnections = 20
   slick.db.minConnections = 1
   slick.db.connectionTimeout = 1800000 // 30 minutes
 }
@@ -54,7 +54,7 @@ jdbc-read-journal {
 
   slick = ${slick}
   slick.db.numThreads = 20
-  slick.db.maxConnections = 100
+  slick.db.maxConnections = 20
   slick.db.minConnections = 1
   slick.db.connectionTimeout = 1800000 // 30 minutes
 }

--- a/src/test/resources/h2-two-read-journals-application.conf
+++ b/src/test/resources/h2-two-read-journals-application.conf
@@ -17,7 +17,7 @@ include "general.conf"
 jdbc-journal {
   slick = ${slick}
   slick.db.numThreads = 20
-  slick.db.maxConnections = 100
+  slick.db.maxConnections = 20
   slick.db.minConnections = 1
   slick.db.connectionTimeout = 1800000 // 30 minutes
 
@@ -39,7 +39,7 @@ jdbc-journal {
 jdbc-snapshot-store {
   slick = ${slick}
   slick.db.numThreads = 20
-  slick.db.maxConnections = 100
+  slick.db.maxConnections = 20
   slick.db.minConnections = 1
   slick.db.connectionTimeout = 1800000 // 30 minutes
 }
@@ -54,7 +54,7 @@ jdbc-read-journal {
 
   slick = ${slick}
   slick.db.numThreads = 20
-  slick.db.maxConnections = 100
+  slick.db.maxConnections = 20
   slick.db.minConnections = 1
   slick.db.connectionTimeout = 1800000 // 30 minutes
 }

--- a/src/test/resources/mysql-application.conf
+++ b/src/test/resources/mysql-application.conf
@@ -18,7 +18,7 @@ include "docker.conf"
 jdbc-journal {
   slick = ${slick}
   slick.db.numThreads = 20
-  slick.db.maxConnections = 100
+  slick.db.maxConnections = 20
   slick.db.minConnections = 1
   slick.db.connectionTimeout = 1800000 // 30 minutes
 
@@ -41,7 +41,7 @@ jdbc-journal {
 jdbc-snapshot-store {
   slick = ${slick}
   slick.db.numThreads = 20
-  slick.db.maxConnections = 100
+  slick.db.maxConnections = 20
   slick.db.minConnections = 1
   slick.db.connectionTimeout = 1800000 // 30 minutes
 }
@@ -56,7 +56,7 @@ jdbc-read-journal {
 
   slick = ${slick}
   slick.db.numThreads = 20
-  slick.db.maxConnections = 100
+  slick.db.maxConnections = 20
   slick.db.minConnections = 1
   slick.db.connectionTimeout = 1800000 // 30 minutes
 }

--- a/src/test/resources/oracle-application.conf
+++ b/src/test/resources/oracle-application.conf
@@ -25,7 +25,7 @@ jdbc-journal {
 
   slick = ${slick}
   slick.db.numThreads = 20
-  slick.db.maxConnections = 100
+  slick.db.maxConnections = 20
   slick.db.minConnections = 1
   slick.db.connectionTimeout = 1800000 // 30 minutes
 
@@ -60,7 +60,7 @@ jdbc-snapshot-store {
 
   slick = ${slick}
   slick.db.numThreads = 20
-  slick.db.maxConnections = 100
+  slick.db.maxConnections = 20
   slick.db.minConnections = 1
   slick.db.connectionTimeout = 1800000 // 30 minutes
 }
@@ -83,7 +83,7 @@ jdbc-read-journal {
 
   slick = ${slick}
   slick.db.numThreads = 20
-  slick.db.maxConnections = 100
+  slick.db.maxConnections = 20
   slick.db.minConnections = 1
   slick.db.connectionTimeout = 1800000 // 30 minutes
 }

--- a/src/test/resources/postgres-application.conf
+++ b/src/test/resources/postgres-application.conf
@@ -18,7 +18,7 @@ include "docker.conf"
 jdbc-journal {
   slick = ${slick}
   slick.db.numThreads = 10
-  slick.db.maxConnections = 30
+  slick.db.maxConnections = 10
   slick.db.minConnections = 1
   slick.db.connectionTimeout = 1800000 // 30 minutes
 
@@ -42,7 +42,7 @@ jdbc-journal {
 jdbc-snapshot-store {
   slick = ${slick}
   slick.db.numThreads = 10
-  slick.db.maxConnections = 30
+  slick.db.maxConnections = 10
   slick.db.minConnections = 1
   slick.db.connectionTimeout = 1800000 // 30 minutes
 }
@@ -57,7 +57,7 @@ jdbc-read-journal {
 
   slick = ${slick}
   slick.db.numThreads = 10
-  slick.db.maxConnections = 30
+  slick.db.maxConnections = 10
   slick.db.minConnections = 1
   slick.db.connectionTimeout = 1800000 // 30 minutes
 }

--- a/src/test/scala/akka/persistence/jdbc/TablesTestSpec.scala
+++ b/src/test/scala/akka/persistence/jdbc/TablesTestSpec.scala
@@ -91,7 +91,7 @@ abstract class TablesTestSpec extends FlatSpec with Matchers {
       |      keepAliveConnection = on // ensures that the database does not get dropped while we are using it
       |
       |      numThreads = 4 // number of cores
-      |      maxConnections = 10 // 2 * numThreads + 1 (if running on an SSD)
+      |      maxConnections = 4  // same as numThreads
       |      minConnections = 4  // same as numThreads
       |    }
       |  }
@@ -151,7 +151,7 @@ abstract class TablesTestSpec extends FlatSpec with Matchers {
       |      keepAliveConnection = on // ensures that the database does not get dropped while we are using it
       |
       |      numThreads = 4 // number of cores
-      |      maxConnections = 10 // 2 * numThreads + 1 (if running on an SSD)
+      |      maxConnections = 4  // same as numThreads
       |      minConnections = 4  // same as numThreads
       |    }
       |  }
@@ -221,7 +221,7 @@ abstract class TablesTestSpec extends FlatSpec with Matchers {
       |      keepAliveConnection = on // ensures that the database does not get dropped while we are using it
       |
       |      numThreads = 4 // number of cores
-      |      maxConnections = 10 // 2 * numThreads + 1 (if running on an SSD)
+      |      maxConnections = 4  // same as numThreads
       |      minConnections = 4  // same as numThreads
       |    }
       |  }

--- a/src/test/scala/akka/persistence/jdbc/configuration/AkkaPersistenceConfigTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/configuration/AkkaPersistenceConfigTest.scala
@@ -82,7 +82,7 @@ class AkkaPersistenceConfigTest extends FlatSpec with Matchers {
       |      keepAliveConnection = on // ensures that the database does not get dropped while we are using it
       |
       |      numThreads = 4 // number of cores
-      |      maxConnections = 10 // 2 * numThreads + 1 (if running on an SSD)
+      |      maxConnections = 4  // same as numThreads
       |      minConnections = 4  // same as numThreads
       |    }
       |  }
@@ -140,7 +140,7 @@ class AkkaPersistenceConfigTest extends FlatSpec with Matchers {
       |      keepAliveConnection = on // ensures that the database does not get dropped while we are using it
       |
       |      numThreads = 4 // number of cores
-      |      maxConnections = 10 // 2 * numThreads + 1 (if running on an SSD)
+      |      maxConnections = 4  // same as numThreads
       |      minConnections = 4  // same as numThreads
       |    }
       |  }
@@ -209,7 +209,7 @@ class AkkaPersistenceConfigTest extends FlatSpec with Matchers {
       |      keepAliveConnection = on // ensures that the database does not get dropped while we are using it
       |
       |      numThreads = 4 // number of cores
-      |      maxConnections = 10 // 2 * numThreads + 1 (if running on an SSD)
+      |      maxConnections = 4  // same as numThreads
       |      minConnections = 4  // same as numThreads
       |    }
       |  }


### PR DESCRIPTION
fixes #177

It appears that numThread must be equal to maxConnections. This PR aligns the values which also prevents a load of warnings in the log

See slick/slick#1614 and the comments below