### PR TITLE
use snapshot table name in its primary key name

### DIFF
--- a/src/main/scala/akka/persistence/jdbc/journal/dao/JournalTables.scala
+++ b/src/main/scala/akka/persistence/jdbc/journal/dao/JournalTables.scala
@@ -35,8 +35,8 @@ trait JournalTables {
     val deleted: Rep[Boolean] = column[Boolean](journalTableCfg.columnNames.deleted, O.Default(false))
     val tags: Rep[Option[String]] = column[Option[String]](journalTableCfg.columnNames.tags, O.Length(255, varying = true))
     val message: Rep[Array[Byte]] = column[Array[Byte]](journalTableCfg.columnNames.message)
-    val pk = primaryKey("journal_pk", (persistenceId, sequenceNumber))
-    val orderingIdx = index("journal_ordering_idx", ordering, unique = true)
+    val pk = primaryKey(s"${tableName}_pk", (persistenceId, sequenceNumber))
+    val orderingIdx = index(s"${tableName}_ordering_idx", ordering, unique = true)
   }
 
   lazy val JournalTable = new TableQuery(tag => new Journal(tag))

--- a/src/main/scala/akka/persistence/jdbc/snapshot/dao/SnapshotTables.scala
+++ b/src/main/scala/akka/persistence/jdbc/snapshot/dao/SnapshotTables.scala
@@ -43,7 +43,7 @@ trait SnapshotTables {
     val sequenceNumber: Rep[Long] = column[Long](snapshotTableCfg.columnNames.sequenceNumber)
     val created: Rep[Long] = column[Long](snapshotTableCfg.columnNames.created)
     val snapshot: Rep[Array[Byte]] = column[Array[Byte]](snapshotTableCfg.columnNames.snapshot)
-    val pk = primaryKey("snapshot_pk", (persistenceId, sequenceNumber))
+    val pk = primaryKey(s"${tableName}_pk", (persistenceId, sequenceNumber))
   }
 
   case class OracleSnapshot(_tableTag: Tag) extends Snapshot(_tableTag) {


### PR DESCRIPTION
The default snapshot table schema used a fixed name (`snapshot_pk`) for the primary key, which makes it impossible to have more than one snapshot table in the same schema (since they both try to create the primary key with the same name). This change makes the name based on the configured table name, so that more than one can coexist.

Thanks.