### PR TITLE
minor improvements on SlickDriver

### DIFF
--- a/src/main/scala/akka/persistence/jdbc/util/SlickDriver.scala
+++ b/src/main/scala/akka/persistence/jdbc/util/SlickDriver.scala
@@ -25,14 +25,24 @@ import slick.jdbc.JdbcProfile
 import slick.jdbc.JdbcBackend._
 
 object SlickDriver {
+
+  def forDriverName(config: Config): JdbcProfile =
+    forDriverName(config, "slick")
+
   def forDriverName(config: Config, path: String): JdbcProfile =
     DatabaseConfig.forConfig[JdbcProfile](path, config).profile
 }
 
 object SlickDatabase {
-  def forConfig(config: Config, slickConfiguration: SlickConfiguration, path: String): Database = {
-    val jndiName = slickConfiguration.jndiName.map(Database.forName(_, None))
-    val jndiDbName = slickConfiguration.jndiDbName.map(new InitialContext().lookup(_).asInstanceOf[Database])
-    jndiName.orElse(jndiDbName).getOrElse(Database.forConfig(path, config))
-  }
+
+  def forConfig(config: Config, slickConfiguration: SlickConfiguration): Database =
+    forConfig(config, slickConfiguration, "slick.db")
+
+  def forConfig(config: Config, slickConfiguration: SlickConfiguration, path: String): Database =
+    slickConfiguration.jndiName
+      .map(Database.forName(_, None))
+      .orElse{
+        slickConfiguration.jndiDbName.map(new InitialContext().lookup(_).asInstanceOf[Database])
+      }
+      .getOrElse(Database.forConfig(path, config))
 }

--- a/src/main/scala/akka/persistence/jdbc/util/SlickDriver.scala
+++ b/src/main/scala/akka/persistence/jdbc/util/SlickDriver.scala
@@ -16,33 +16,56 @@
 
 package akka.persistence.jdbc.util
 
+import akka.annotation.InternalApi
 import javax.naming.InitialContext
-
 import akka.persistence.jdbc.config.SlickConfiguration
 import com.typesafe.config.Config
 import slick.basic.DatabaseConfig
 import slick.jdbc.JdbcProfile
 import slick.jdbc.JdbcBackend._
 
+/**
+ * INTERNAL API
+ */
 object SlickDriver {
 
+  /**
+   * INTERNAL API
+   */
+  @deprecated(message = "Internal API, will be removed in 4.0.0", since = "3.4.0")
   def forDriverName(config: Config): JdbcProfile =
     forDriverName(config, "slick")
 
-  def forDriverName(config: Config, path: String): JdbcProfile =
+  /**
+   * INTERNAL API
+   */
+  private[jdbc] def forDriverName(config: Config, path: String): JdbcProfile =
     DatabaseConfig.forConfig[JdbcProfile](path, config).profile
 }
 
+/**
+ * INTERNAL API
+ */
 object SlickDatabase {
 
-  def forConfig(config: Config, slickConfiguration: SlickConfiguration): Database =
+  /**
+   * INTERNAL API
+   */
+  @deprecated(message = "Internal API, will be removed in 4.0.0", since = "3.4.0")
+  def forConfig(config: Config, slickConfiguration: SlickConfiguration): Database = {
     forConfig(config, slickConfiguration, "slick.db")
+  }
 
-  def forConfig(config: Config, slickConfiguration: SlickConfiguration, path: String): Database =
+  /**
+   * INTERNAL API
+   */
+  private[jdbc] def forConfig(config: Config, slickConfiguration: SlickConfiguration, path: String): Database = {
     slickConfiguration.jndiName
       .map(Database.forName(_, None))
-      .orElse{
-        slickConfiguration.jndiDbName.map(new InitialContext().lookup(_).asInstanceOf[Database])
+      .orElse {
+        slickConfiguration.jndiDbName.map(
+          new InitialContext().lookup(_).asInstanceOf[Database])
       }
       .getOrElse(Database.forConfig(path, config))
+  }
 }


### PR DESCRIPTION
This PR adds back overloaded methods for `SlickDriver.forDriverName` and `SlickDriver.forConfig`. Those method got an extra param (path: String) in PR #151. 

That extra param is useless for those using JNDI lookup (eg: Lagom), so it's nice to have a variant without it and also to keep backward compatibility with previous versions. 

