### PR TITLE
Documentation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,11 @@ needs to be configured in the application.conf. In addition, you might want to c
 the database to be closed automatically:
 
 ```
+akka-persistence-jdbc {
+  database-provider-fqcn = "com.mypackage.CustomSlickDatabaseProvider"
+}
 jdbc-journal {
   use-shared-db = "enabled" // setting this to any non-empty string prevents the journal from closing the database on shutdown
-  database-provider-fqcn = "com.mypackage.CustomSlickDatabaseProvider"
 }
 jdbc-snapshot-store {
   use-shared-db = "enabled" // setting this to any non-empty string prevents the snapshot-journal from closing the database on shutdown

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -58,7 +58,6 @@ akka-persistence-jdbc {
         # driver = "org.postgresql.Driver"
 
         # hikariCP settings; see: https://github.com/brettwooldridge/HikariCP
-        # read: https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
         # Slick will use an async executor with a fixed size queue of 10.000 objects
         # The async executor is a connection pool for asynchronous execution of blocking I/O actions.
         # This is used for the asynchronous query execution API on top of blocking back-ends like JDBC.
@@ -98,13 +97,10 @@ akka-persistence-jdbc {
         # ensures that the database does not get dropped while we are using it
         keepAliveConnection = on
 
-        # 5 * number of cores
+        # See some tips on thread/connection pool sizing on https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
+        # Keep in mind that the number of threads must equal the maximum number of connections.
         numThreads = 20
-
-        # 5 * number of threads
         maxConnections = 20
-
-        # number of threads
         minConnections = 20
       }
     }
@@ -186,7 +182,6 @@ jdbc-journal {
       # driver = "org.postgresql.Driver"
 
       # hikariCP settings; see: https://github.com/brettwooldridge/HikariCP
-      # read: https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
       # Slick will use an async executor with a fixed size queue of 10.000 objects
       # The async executor is a connection pool for asynchronous execution of blocking I/O actions.
       # This is used for the asynchronous query execution API on top of blocking back-ends like JDBC.
@@ -226,13 +221,10 @@ jdbc-journal {
       # ensures that the database does not get dropped while we are using it
       keepAliveConnection = on
 
-      # 5 * number of cores
+      # See some tips on thread/connection pool sizing on https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
+      # Keep in mind that the number of threads must equal the maximum number of connections.
       numThreads = 20
-
-      # 5 * number of threads
       maxConnections = 20
-
-      # number of threads
       minConnections = 20
     }
   }
@@ -294,7 +286,6 @@ jdbc-snapshot-store {
       # driver = "org.postgresql.Driver"
 
       # hikariCP settings; see: https://github.com/brettwooldridge/HikariCP
-      # read: https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
       # Slick will use an async executor with a fixed size queue of 10.000 objects
       # The async executor is a connection pool for asynchronous execution of blocking I/O actions.
       # This is used for the asynchronous query execution API on top of blocking back-ends like JDBC.
@@ -334,13 +325,10 @@ jdbc-snapshot-store {
       # ensures that the database does not get dropped while we are using it
       keepAliveConnection = on
 
-      # 5 * number of cores
+      # See some tips on thread/connection pool sizing on https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
+      # Keep in mind that the number of threads must equal the maximum number of connections.
       numThreads = 20
-
-      # 5 * number of threads
       maxConnections = 20
-
-      # number of threads
       minConnections = 20
     }
   }
@@ -443,7 +431,6 @@ jdbc-read-journal {
       # driver = "org.postgresql.Driver"
 
       # hikariCP settings; see: https://github.com/brettwooldridge/HikariCP
-      # read: https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
       # Slick will use an async executor with a fixed size queue of 10.000 objects
       # The async executor is a connection pool for asynchronous execution of blocking I/O actions.
       # This is used for the asynchronous query execution API on top of blocking back-ends like JDBC.
@@ -483,13 +470,10 @@ jdbc-read-journal {
       # ensures that the database does not get dropped while we are using it
       keepAliveConnection = on
 
-      # 5 * number of cores
+      # See some tips on thread/connection pool sizing on https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
+      # Keep in mind that the number of threads must equal the maximum number of connections.
       numThreads = 20
-
-      # number of threads
       maxConnections = 20
-
-      # number of threads
       minConnections = 20
     }
   }


### PR DESCRIPTION
- Fixed a mistake in the configuration example for custom database providers
- Improved documentation on thread/connection pool sizing (specifically by removing the vague 5 * number of cores recommendation and pointing to a better resource)