### PR TITLE
Add support for SQL Server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,12 @@ services:
   - postgresql
   - docker
 before_install:
-#  - docker pull mysql
-#  - docker run --name mysql -d -p 127.0.0.1:3306:3306 -e MYSQL_ROOT_PASSWORD=root mysql
-#  - docker inspect mysql
   - docker pull alexeiled/docker-oracle-xe-11g
+  - docker pull topaztechnology/mssql-server-linux
   - docker run --name oracle -d -p 127.0.0.1:1521:1521 -e ORACLE_ALLOW_REMOTE=true alexeiled/docker-oracle-xe-11g
+  - docker run --name sqlserver -d -p 127.0.0.1:1433:1433 -e DBCA_TOTAL_MEMORY=1024 -e ACCEPT_EULA=Y -e SQL_USER=docker -e SQL_PASSWORD=docker -e SQL_DB=docker topaztechnology/mssql-server-linux
   - docker inspect oracle
+  - docker inspect sqlserver
   - docker ps -a
 scala:
   - 2.11.12

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Configure `slick`:
   - `slick.jdbc.MySQLProfile$`
   - `slick.jdbc.H2Profile$`
   - `slick.jdbc.OracleProfile$`
+  - `slick.jdbc.SQLServerProfile$`
 
 ## Database Schema
 
@@ -62,6 +63,7 @@ Configure `slick`:
 - [MySQL Schema](https://github.com/dnvriend/akka-persistence-jdbc/blob/master/src/test/resources/schema/mysql/mysql-schema.sql)
 - [H2 Schema](https://github.com/dnvriend/akka-persistence-jdbc/blob/master/src/test/resources/schema/h2/h2-schema.sql)
 - [Oracle Schema](https://github.com/dnvriend/akka-persistence-jdbc/blob/master/src/test/resources/schema/oracle/oracle-schema.sql)
+- [SQL Server Schema](https://github.com/dnvriend/akka-persistence-jdbc/blob/master/src/test/resources/schema/sqlserver/sqlserver-schema.sql)
 
 ## Configuration
 
@@ -80,6 +82,7 @@ configuration shows how this is configured:
 - [MySQL](https://github.com/dnvriend/akka-persistence-jdbc/blob/master/src/test/resources/mysql-application.conf)
 - [H2](https://github.com/dnvriend/akka-persistence-jdbc/blob/master/src/test/resources/h2-application.conf)
 - [Oracle](https://github.com/dnvriend/akka-persistence-jdbc/blob/master/src/test/resources/oracle-application.conf)
+- [SQL Server](https://github.com/dnvriend/akka-persistence-jdbc/blob/master/src/test/resources/sqlserver-application.conf)
 
 ### Sharing the database connection pool between the journals
 
@@ -89,6 +92,7 @@ In order to create only one connection pool which is shared between all journals
 - [MySQL](https://github.com/dnvriend/akka-persistence-jdbc/blob/master/src/test/resources/mysql-shared-db-application.conf)
 - [H2](https://github.com/dnvriend/akka-persistence-jdbc/blob/master/src/test/resources/h2-shared-db-application.conf)
 - [Oracle](https://github.com/dnvriend/akka-persistence-jdbc/blob/master/src/test/resources/oracle-shared-db-application.conf)
+- [SQL Server](https://github.com/dnvriend/akka-persistence-jdbc/blob/master/src/test/resources/sqlserver-shared-db-application.conf)
 
 ### Customized loading of the db connection
 

--- a/build.sh
+++ b/build.sh
@@ -17,7 +17,9 @@ done;
 }
 rm ./bintray.sbt
 
+wait 5432 PostgreSQL
 wait 3306 MySQL
 wait 1521 Oracle
+wait 1433 SqlSever
 
 sbt test

--- a/project/ProjectAutoPlugin.scala
+++ b/project/ProjectAutoPlugin.scala
@@ -84,6 +84,7 @@ object ProjectAutoPlugin extends AutoPlugin {
    libraryDependencies += "org.postgresql" % "postgresql" % "42.2.5" % Test,
    libraryDependencies += "com.h2database" % "h2" % "1.4.197" % Test,
    libraryDependencies += "mysql" % "mysql-connector-java" % "8.0.12" % Test,
+   libraryDependencies += "com.microsoft.sqlserver" % "mssql-jdbc" % "7.0.0.jre8" % Test,
    libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3" % Test,
    libraryDependencies += "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion % Test,
    libraryDependencies += "com.typesafe.akka" %% "akka-persistence-tck" % AkkaVersion % Test,

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -25,3 +25,16 @@ oracle:
     - "DBCA_TOTAL_MEMORY=1024"
   ports:
     - "1521:1521" # DB_CONN: credentials (system:oracle)
+
+sqlserver:
+  image: topaztechnology/mssql-server-linux
+  container_name: sqlserver-test
+  environment:
+    - "TZ=Europe/Amsterdam"
+    - "DBCA_TOTAL_MEMORY=1024"
+    - "ACCEPT_EULA=Y"
+    - "SQL_USER=docker"
+    - "SQL_PASSWORD=docker"
+    - "SQL_DB=docker"
+  ports:
+    - "1433:1433" # credentials (docker:docker)

--- a/scripts/launch-sqlserver.sh
+++ b/scripts/launch-sqlserver.sh
@@ -17,7 +17,7 @@
 export VM_HOST="${VM_HOST:-localhost}"
 
 # Wait for a certain service to become available
-# Usage: wait 3306 Mysql
+# Usage: wait 1433 SqlServer
 wait() {
 while true; do
   if ! nc -z $VM_HOST $1
@@ -31,12 +31,7 @@ while true; do
 done;
 }
 
-docker-compose -f scripts/docker-compose.yml rm -f
-docker-compose -f scripts/docker-compose.yml up -d
-wait 3306 MySQL
-wait 5432 Postgres
-wait 1521 Oracle
+docker-compose -f scripts/sqlserver.yml kill
+docker-compose -f scripts/sqlserver.yml rm -f
+docker-compose -f scripts/sqlserver.yml up -d
 wait 1433 SqlServer
-sbt clean +test
-docker-compose -f scripts/docker-compose.yml stop
-docker-compose -f scripts/docker-compose.yml rm -f

--- a/scripts/sqlserver-cli.sh
+++ b/scripts/sqlserver-cli.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+echo "==================  Help for SqlServer cli  ========================"
+echo "================================================================="
+docker exec -it sqlserver /opt/mssql-tools/bin/sqlcmd -S localhost -U docker -P docker -d docker

--- a/scripts/sqlserver.yml
+++ b/scripts/sqlserver.yml
@@ -1,0 +1,12 @@
+sqlserver:
+  image: topaztechnology/mssql-server-linux
+  container_name: sqlserver
+  environment:
+    - "TZ=Europe/Amsterdam"
+    - "DBCA_TOTAL_MEMORY=1024"
+    - "ACCEPT_EULA=Y"
+    - "SQL_USER=docker"
+    - "SQL_PASSWORD=docker"
+    - "SQL_DB=docker"
+  ports:
+    - "1433:1433" # credentials (docker:docker)

--- a/src/test/resources/schema/sqlserver/sqlserver-schema.sql
+++ b/src/test/resources/schema/sqlserver/sqlserver-schema.sql
@@ -1,0 +1,23 @@
+DROP TABLE IF EXISTS journal;
+
+CREATE TABLE journal (
+	"ordering" BIGINT IDENTITY(1,1) NOT NULL,
+	"deleted" BIT NULL DEFAULT 0,
+	"persistence_id" VARCHAR(255) NOT NULL,
+	"sequence_number" NUMERIC(10,0) NOT NULL,
+	"tags" VARCHAR(255) NULL DEFAULT NULL,
+	"message" VARBINARY(max) NOT NULL,
+	PRIMARY KEY ("persistence_id", "sequence_number")
+);
+
+CREATE UNIQUE INDEX journal_ordering_idx ON journal (ordering);
+
+DROP TABLE IF EXISTS snapshot;
+
+CREATE TABLE snapshot (
+  "persistence_id" VARCHAR(255) NOT NULL,
+  "sequence_number" NUMERIC(10,0) NOT NULL,
+  "created" NUMERIC NOT NULL,
+  "snapshot" VARBINARY(max) NOT NULL,
+  PRIMARY KEY ("persistence_id", "sequence_number")
+);

--- a/src/test/resources/sqlserver-application-with-hard-delete.conf
+++ b/src/test/resources/sqlserver-application-with-hard-delete.conf
@@ -1,4 +1,3 @@
-#
 # Copyright 2016 Dennis Vriend
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,29 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-#!/bin/bash
-export VM_HOST="${VM_HOST:-localhost}"
 
-# Wait for a certain service to become available
-# Usage: wait 3306 Mysql
-wait() {
-while true; do
-  if ! nc -z $VM_HOST $1
-  then
-    echo "$2 not available, retrying..."
-    sleep 1
-  else
-    echo "$2 is available"
-    break;
-  fi
-done;
-}
+// general.conf is included only for shared settings used for the akka-persistence-jdbc tests
+include "general.conf"
+include "sqlserver-application.conf"
 
-docker-compose -f scripts/docker-compose.yml kill
-docker-compose -f scripts/docker-compose.yml rm -f
-docker-compose -f scripts/docker-compose.yml up -d
-wait 3306 MySQL
-wait 5432 Postgres
-wait 1521 Oracle
-wait 1433 SqlServer
+akka-persistence-jdbc.logicalDeletion.enable = false

--- a/src/test/resources/sqlserver-application.conf
+++ b/src/test/resources/sqlserver-application.conf
@@ -1,0 +1,84 @@
+# Copyright 2016 Dennis Vriend
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include "general.conf"
+
+akka {
+  persistence {
+    journal {
+      plugin = "jdbc-journal"
+      // Enable the line below to automatically start the journal when the actorsystem is started
+      // auto-start-journals = ["jdbc-journal"]
+    }
+    snapshot-store {
+      plugin = "jdbc-snapshot-store"
+      // Enable the line below to automatically start the snapshot-store when the actorsystem is started
+      // auto-start-snapshot-stores = ["jdbc-snapshot-store"]
+    }
+  }
+}
+
+jdbc-journal {
+  tables {
+    journal {
+      tableName = "journal"
+      schemaName = "dbo"
+    }
+  }
+
+  slick = ${slick}
+}
+
+# the akka-persistence-snapshot-store in use
+jdbc-snapshot-store {
+  tables {
+    snapshot {
+      tableName = "snapshot"
+      schemaName = "dbo"
+    }
+  }
+
+  slick = ${slick}
+}
+
+# the akka-persistence-query provider in use
+jdbc-read-journal {
+  tables {
+    journal {
+      tableName = "journal"
+      schemaName = "dbo"
+    }
+  }
+
+  slick = ${slick}
+}
+
+slick {
+  profile = "slick.jdbc.SQLServerProfile$"
+  db {
+    host = ${docker.host}
+    host = ${?SQLSERVER_HOST}
+    port = "1433"
+    port = ${?SQLSERVER_PORT}
+    url = "jdbc:sqlserver://"${slick.db.host}":"${slick.db.port}";databaseName=docker;integratedSecurity=false"
+    user = "docker"
+    user = ${?SQLSERVER_USER}
+    password = "docker"
+    password = ${?SQLSERVER_PASSWORD}
+    driver = "com.microsoft.sqlserver.jdbc.SQLServerDriver"
+    numThreads = 5
+    maxConnections = 5
+    minConnections = 1
+  }
+}

--- a/src/test/resources/sqlserver-shared-db-application.conf
+++ b/src/test/resources/sqlserver-shared-db-application.conf
@@ -1,0 +1,67 @@
+# Copyright 2016 Dennis Vriend
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include "general.conf"
+
+akka {
+  persistence {
+    journal {
+      plugin = "jdbc-journal"
+      // Enable the line below to automatically start the journal when the actorsystem is started
+      // auto-start-journals = ["jdbc-journal"]
+    }
+    snapshot-store {
+      plugin = "jdbc-snapshot-store"
+      // Enable the line below to automatically start the snapshot-store when the actorsystem is started
+      // auto-start-snapshot-stores = ["jdbc-snapshot-store"]
+    }
+  }
+}
+
+akka-persistence-jdbc {
+  shared-databases {
+    slick {
+      profile = "slick.jdbc.SQLServerProfile$"
+      db {
+        host = ${docker.host}
+        host = ${?SQLSERVER_HOST}
+        url = "jdbc:sqlserver://"${akka-persistence-jdbc.shared-databases.slick.db.host}":1433;databaseName=docker;integratedSecurity=false;"
+        user = "docker"
+        user = ${?SQLSERVER_USER}
+        // This password needs to include at least 8 characters of at least three of these four categories:
+        // uppercase letters, lowercase letters, numbers and non-alphanumeric symbols.
+        password = "docker"
+        password = ${?SQLSERVER_PASSWORD}
+        driver = "com.microsoft.sqlserver.jdbc.SQLServerDriver"
+        numThreads = 5
+        maxConnections = 5
+        minConnections = 1
+      }
+    }
+  }
+}
+
+jdbc-journal {
+  use-shared-db = "slick"
+}
+
+# the akka-persistence-snapshot-store in use
+jdbc-snapshot-store {
+  use-shared-db = "slick"
+}
+
+# the akka-persistence-query provider in use
+jdbc-read-journal {
+  use-shared-db = "slick"
+}

--- a/src/test/scala/akka/persistence/jdbc/journal/JdbcJournalPerfSpec.scala
+++ b/src/test/scala/akka/persistence/jdbc/journal/JdbcJournalPerfSpec.scala
@@ -148,7 +148,20 @@ class OracleJournalPerfSpecPhysicalDelete extends OracleJournalPerfSpec {
   this.cfg.withValue("jdbc-journal.logicalDelete", ConfigValueFactory.fromAnyRef(false))
 }
 
+class SqlServerJournalPerfSpec extends JdbcJournalPerfSpec(ConfigFactory.load("sqlserver-application.conf"), SqlServer()) {
+  override def eventsCount: Int = 100
+}
+
+class SqlServerJournalPerfSpecSharedDb extends JdbcJournalPerfSpec(ConfigFactory.load("sqlserver-shared-db-application.conf"), SqlServer()) {
+  override def eventsCount: Int = 100
+}
+
+class SqlServerJournalPerfSpecPhysicalDelete extends SqlServerJournalPerfSpec {
+  this.cfg.withValue("jdbc-journal.logicalDelete", ConfigValueFactory.fromAnyRef(false))
+}
+
 class H2JournalPerfSpec extends JdbcJournalPerfSpec(ConfigFactory.load("h2-application.conf"), H2())
+
 class H2JournalPerfSpecSharedDb extends JdbcJournalPerfSpec(ConfigFactory.load("h2-shared-db-application.conf"), H2())
 
 class H2JournalPerfSpecPhysicalDelete extends H2JournalPerfSpec {

--- a/src/test/scala/akka/persistence/jdbc/journal/JdbcJournalSpec.scala
+++ b/src/test/scala/akka/persistence/jdbc/journal/JdbcJournalSpec.scala
@@ -62,6 +62,7 @@ class PostgresJournalSpecSharedDb extends JdbcJournalSpec(ConfigFactory.load("po
 class PostgresJournalSpecPhysicalDelete extends JdbcJournalSpec(ConfigFactory.load("postgres-application.conf")
   .withValue("jdbc-journal.logicalDelete", ConfigValueFactory.fromAnyRef(false)), Postgres())
 
+class MySQLJournalSpec extends JdbcJournalSpec(ConfigFactory.load("mysql-application.conf"), MySQL())
 class MySQLJournalSpecSharedDb extends JdbcJournalSpec(ConfigFactory.load("mysql-shared-db-application.conf"), MySQL())
 class MySQLJournalSpecPhysicalDelete extends JdbcJournalSpec(ConfigFactory.load("mysql-application.conf")
   .withValue("jdbc-journal.logicalDelete", ConfigValueFactory.fromAnyRef(false)), MySQL())
@@ -70,6 +71,11 @@ class OracleJournalSpec extends JdbcJournalSpec(ConfigFactory.load("oracle-appli
 class OracleJournalSpecSharedDb extends JdbcJournalSpec(ConfigFactory.load("oracle-shared-db-application.conf"), Oracle())
 class OracleJournalSpecPhysicalDelete extends JdbcJournalSpec(ConfigFactory.load("oracle-application.conf")
   .withValue("jdbc-journal.logicalDelete", ConfigValueFactory.fromAnyRef(false)), Oracle())
+
+class SqlServerJournalSpec extends JdbcJournalSpec(ConfigFactory.load("sqlserver-application.conf"), SqlServer())
+class SqlServerJournalSpecSharedDb extends JdbcJournalSpec(ConfigFactory.load("sqlserver-shared-db-application.conf"), SqlServer())
+class SqlServerJournalSpecPhysicalDelete extends JdbcJournalSpec(ConfigFactory.load("sqlserver-application.conf")
+  .withValue("jdbc-journal.logicalDelete", ConfigValueFactory.fromAnyRef(false)), SqlServer())
 
 class H2JournalSpec extends JdbcJournalSpec(ConfigFactory.load("h2-application.conf"), H2())
 class H2JournalSpecSharedDb extends JdbcJournalSpec(ConfigFactory.load("h2-shared-db-application.conf"), H2())

--- a/src/test/scala/akka/persistence/jdbc/query/AllPersistenceIdsTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/AllPersistenceIdsTest.scala
@@ -70,4 +70,6 @@ class MySQLScalaAllPersistenceIdsTest extends AllPersistenceIdsTest("mysql-appli
 
 class OracleScalaAllPersistenceIdsTest extends AllPersistenceIdsTest("oracle-application.conf") with OracleCleaner
 
+class SqlServerScalaAllPersistenceIdsTest extends AllPersistenceIdsTest("sqlserver-application.conf") with SqlServerCleaner
+
 class H2ScalaAllPersistenceIdsTest extends AllPersistenceIdsTest("h2-application.conf") with H2Cleaner

--- a/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByPersistenceIdTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByPersistenceIdTest.scala
@@ -184,4 +184,6 @@ class MySQLScalaCurrentEventsByPersistenceIdTest extends CurrentEventsByPersiste
 
 class OracleScalaCurrentEventsByPersistenceIdTest extends CurrentEventsByPersistenceIdTest("oracle-shared-db-application.conf") with OracleCleaner
 
+class SqlServerScalaCurrentEventsByPersistenceIdTest extends CurrentEventsByPersistenceIdTest("sqlserver-shared-db-application.conf") with SqlServerCleaner
+
 class H2ScalaCurrentEventsByPersistenceIdTest extends CurrentEventsByPersistenceIdTest("h2-shared-db-application.conf") with H2Cleaner

--- a/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByTagTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByTagTest.scala
@@ -219,4 +219,6 @@ class MySQLScalaCurrentEventsByTagTest extends CurrentEventsByTagTest("mysql-sha
 
 class OracleScalaCurrentEventsByTagTest extends CurrentEventsByTagTest("oracle-shared-db-application.conf") with OracleCleaner
 
+class SqlServerScalaCurrentEventsByTagTest extends CurrentEventsByTagTest("sqlserver-shared-db-application.conf") with SqlServerCleaner
+
 class H2ScalaCurrentEventsByTagTest extends CurrentEventsByTagTest("h2-shared-db-application.conf") with H2Cleaner

--- a/src/test/scala/akka/persistence/jdbc/query/CurrentPersistenceIdsTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/CurrentPersistenceIdsTest.scala
@@ -52,4 +52,6 @@ class MySQLScalaCurrentPersistenceIdsTest extends CurrentPersistenceIdsTest("mys
 
 class OracleScalaCurrentPersistenceIdsTest extends CurrentPersistenceIdsTest("oracle-shared-db-application.conf") with OracleCleaner
 
+class SqlServerScalaCurrentPersistenceIdsTest extends CurrentPersistenceIdsTest("sqlserver-application.conf") with SqlServerCleaner
+
 class H2ScalaCurrentPersistenceIdsTest extends CurrentPersistenceIdsTest("h2-shared-db-application.conf") with H2Cleaner

--- a/src/test/scala/akka/persistence/jdbc/query/EventAdapterTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/EventAdapterTest.scala
@@ -204,4 +204,6 @@ class MySQLScalaEventAdapterTest extends EventAdapterTest("mysql-application.con
 
 class OracleScalaEventAdapterTest extends EventAdapterTest("oracle-application.conf") with OracleCleaner
 
+class SqlServerScalaEventAdapterTest extends EventAdapterTest("sqlserver-application.conf") with SqlServerCleaner
+
 class H2ScalaEventAdapterTest extends EventAdapterTest("h2-application.conf") with H2Cleaner

--- a/src/test/scala/akka/persistence/jdbc/query/EventsByPersistenceIdTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/EventsByPersistenceIdTest.scala
@@ -224,4 +224,6 @@ class MySQLScalaEventsByPersistenceIdTest extends EventsByPersistenceIdTest("mys
 
 class OracleScalaEventsByPersistenceIdTest extends EventsByPersistenceIdTest("oracle-application.conf") with OracleCleaner
 
+class SqlServerScalaEventsByPersistenceIdTest extends EventsByPersistenceIdTest("sqlserver-application.conf") with SqlServerCleaner
+
 class H2ScalaEventsByPersistenceIdTest extends EventsByPersistenceIdTest("h2-application.conf") with H2Cleaner

--- a/src/test/scala/akka/persistence/jdbc/query/EventsByTagTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/EventsByTagTest.scala
@@ -359,4 +359,6 @@ class OracleScalaEventByTagTest extends EventsByTagTest("oracle-application.conf
   override def timeoutMultiplier: Int = 4
 }
 
+class SqlServerScalaEventByTagTest extends EventsByTagTest("sqlserver-application.conf") with SqlServerCleaner
+
 class H2ScalaEventsByTagTest extends EventsByTagTest("h2-application.conf") with H2Cleaner

--- a/src/test/scala/akka/persistence/jdbc/query/HardDeleteQueryTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/HardDeleteQueryTest.scala
@@ -98,6 +98,11 @@ abstract class HardDeleteQueryTest(config: String) extends QueryTestSpec(config)
 }
 
 class PostgresHardDeleteQueryTest extends HardDeleteQueryTest("postgres-application-with-hard-delete.conf") with PostgresCleaner
-class MySQLHardDeleteQueryTest extends HardDeleteQueryTest("mysql-application-with-hard-delete") with MysqlCleaner
-class OracleHardDeleteQueryTest extends HardDeleteQueryTest("oracle-application-with-hard-delete") with OracleCleaner
-class H2HardDeleteQueryTest extends HardDeleteQueryTest("h2-application-with-hard-delete") with H2Cleaner
+
+class MySQLHardDeleteQueryTest extends HardDeleteQueryTest("mysql-application-with-hard-delete.conf") with MysqlCleaner
+
+class OracleHardDeleteQueryTest extends HardDeleteQueryTest("oracle-application-with-hard-delete.conf") with OracleCleaner
+
+class SqlServerHardDeleteQueryTest extends HardDeleteQueryTest("sqlserver-application-with-hard-delete.conf") with SqlServerCleaner
+
+class H2HardDeleteQueryTest extends HardDeleteQueryTest("h2-application-with-hard-delete.conf") with H2Cleaner

--- a/src/test/scala/akka/persistence/jdbc/query/LogicalDeleteQueryTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/LogicalDeleteQueryTest.scala
@@ -93,7 +93,12 @@ abstract class LogicalDeleteQueryTest(config: String) extends QueryTestSpec(conf
   }
 }
 
-class PostgresLogicalDeleteQueryTest extends LogicalDeleteQueryTest("postgres-application") with PostgresCleaner
-class MySQLLogicalDeleteQueryTest extends LogicalDeleteQueryTest("mysql-application") with MysqlCleaner
-class OracleLogicalDeleteQueryTest extends LogicalDeleteQueryTest("oracle-application") with OracleCleaner
-class H2LogicalDeleteQueryTest extends LogicalDeleteQueryTest("h2-application") with H2Cleaner
+class PostgresLogicalDeleteQueryTest extends LogicalDeleteQueryTest("postgres-application.conf") with PostgresCleaner
+
+class MySQLLogicalDeleteQueryTest extends LogicalDeleteQueryTest("mysql-application.conf") with MysqlCleaner
+
+class OracleLogicalDeleteQueryTest extends LogicalDeleteQueryTest("oracle-application.conf") with OracleCleaner
+
+class SqlServerLogicalDeleteQueryTest extends LogicalDeleteQueryTest("sqlserver-application.conf") with SqlServerCleaner
+
+class H2LogicalDeleteQueryTest extends LogicalDeleteQueryTest("h2-application.conf") with H2Cleaner

--- a/src/test/scala/akka/persistence/jdbc/query/QueryTestSpec.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/QueryTestSpec.scala
@@ -293,6 +293,34 @@ trait OracleCleaner extends QueryTestSpec {
   }
 }
 
+trait SqlServerCleaner extends QueryTestSpec {
+  import akka.persistence.jdbc.util.Schema.SqlServer
+
+  val actionsClearSqlServer =
+    DBIO.seq(
+      sqlu"""TRUNCATE TABLE journal""",
+      sqlu"""TRUNCATE TABLE snapshot""",
+      sqlu"""DBCC CHECKIDENT('journal', RESEED, 1)""").transactionally
+
+  def clearSqlServer(): Unit =
+    withDatabase(_.run(actionsClearSqlServer).futureValue)
+
+  override def beforeAll() = {
+    dropCreate(SqlServer())
+    super.beforeAll()
+  }
+
+  override def afterAll(): Unit = {
+    dropCreate(SqlServer())
+    super.afterAll()
+  }
+
+  override def beforeEach(): Unit = {
+    clearSqlServer()
+    super.beforeEach()
+  }
+}
+
 trait H2Cleaner extends QueryTestSpec {
   import akka.persistence.jdbc.util.Schema.H2
 

--- a/src/test/scala/akka/persistence/jdbc/serialization/StoreOnlySerializableMessagesTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/serialization/StoreOnlySerializableMessagesTest.scala
@@ -19,7 +19,7 @@ package akka.persistence.jdbc.serialization
 import akka.actor.{ ActorRef, Props }
 import akka.event.LoggingReceive
 import akka.persistence.jdbc.SharedActorSystemTestSpec
-import akka.persistence.jdbc.util.Schema.{ H2, MySQL, Oracle, Postgres, SchemaType }
+import akka.persistence.jdbc.util.Schema._
 import akka.persistence.{ PersistentActor, RecoveryCompleted }
 import akka.testkit.TestProbe
 
@@ -131,5 +131,7 @@ class PostgresStoreOnlySerializableMessagesTest extends StoreOnlySerializableMes
 class MySQLStoreOnlySerializableMessagesTest extends StoreOnlySerializableMessagesTest("mysql-application.conf", MySQL())
 
 class OracleStoreOnlySerializableMessagesTest extends StoreOnlySerializableMessagesTest("oracle-application.conf", Oracle())
+
+class SqlServerStoreOnlySerializableMessagesTest extends StoreOnlySerializableMessagesTest("sqlserver-application.conf", SqlServer())
 
 class H2StoreOnlySerializableMessagesTest extends StoreOnlySerializableMessagesTest("h2-application.conf", H2())

--- a/src/test/scala/akka/persistence/jdbc/snapshot/JdbcSnapshotStoreSpec.scala
+++ b/src/test/scala/akka/persistence/jdbc/snapshot/JdbcSnapshotStoreSpec.scala
@@ -54,4 +54,6 @@ class MySQLSnapshotStoreSpec extends JdbcSnapshotStoreSpec(ConfigFactory.load("m
 
 class OracleSnapshotStoreSpec extends JdbcSnapshotStoreSpec(ConfigFactory.load("oracle-application.conf"), Oracle())
 
+class SqlServerSnapshotStoreSpec extends JdbcSnapshotStoreSpec(ConfigFactory.load("sqlserver-application.conf"), SqlServer())
+
 class H2SnapshotStoreSpec extends JdbcSnapshotStoreSpec(ConfigFactory.load("h2-application.conf"), H2())

--- a/src/test/scala/akka/persistence/jdbc/util/DropCreate.scala
+++ b/src/test/scala/akka/persistence/jdbc/util/DropCreate.scala
@@ -28,6 +28,7 @@ object Schema {
   final case class H2(schema: String = "schema/h2/h2-schema.sql") extends SchemaType
   final case class MySQL(schema: String = "schema/mysql/mysql-schema.sql") extends SchemaType
   final case class Oracle(schema: String = "schema/oracle/oracle-schema.sql") extends SchemaType
+  final case class SqlServer(schema: String = "schema/sqlserver/sqlserver-schema.sql") extends SchemaType
 }
 
 trait DropCreate extends ClasspathResources {


### PR DESCRIPTION
Adds SQL Server schema and test updates. I created a derived SQL server [image](https://hub.docker.com/r/topaztechnology/mssql-server-linux/) that allows login and database creation on startup to facilitate testing.

Write performance was initially poor vs Postgres, but significantly improved with use of `transactionally` in  `BaseByteArrayJournalDao.writeJournalRows`

This was based on a closed PR #108, thanks to @naferx