### PR TITLE
Investigation if the legacy and new table definitions can be split out

### DIFF
--- a/src/main/scala/akka/persistence/jdbc/journal/dao/ByteArrayJournalDao.scala
+++ b/src/main/scala/akka/persistence/jdbc/journal/dao/ByteArrayJournalDao.scala
@@ -17,6 +17,8 @@
 package akka.persistence.jdbc
 package journal.dao
 
+import java.io.NotSerializableException
+
 import akka.{ Done, NotUsed }
 import akka.persistence.jdbc.config.JournalConfig
 import akka.persistence.jdbc.serialization.FlowPersistentReprSerializer
@@ -132,7 +134,7 @@ trait BaseByteArrayJournalDao extends JournalDaoWithUpdates {
       case Success(t)  => t
       case Failure(ex) => throw new IllegalArgumentException(s"Failed to serialize ${write.getClass} for update of [$persistenceId] @ [$sequenceNr]", ex)
     }
-    db.run(queries.update(persistenceId, sequenceNr, serializedRow).map(_ => Done))
+    db.run(queries.update(persistenceId, sequenceNr, serializedRow.message, serializedRow.event, serializedRow.serId, serializedRow.serManifest).map(_ => Done))
   }
 
   private def highestMarkedSequenceNr(persistenceId: String) =
@@ -170,7 +172,6 @@ trait H2JournalDao extends JournalDao {
 
 class ByteArrayJournalDao(val db: Database, val profile: JdbcProfile, val journalConfig: JournalConfig, serialization: Serialization)(implicit val ec: ExecutionContext, val mat: Materializer) extends BaseByteArrayJournalDao with H2JournalDao {
   val queries = new JournalQueries(profile, journalConfig.journalTableConfiguration)
-  val serializer = new ByteArrayJournalSerializer(serialization, journalConfig.pluginConfig.tagSeparator)
-  val legacySerializer = new LegacyByteArrayJournalSerializer(serialization, journalConfig.pluginConfig.tagSeparator, journalConfig.journalTableConfiguration.writeMessageColumn)
+  val serializer = new ByteArrayJournalSerializer(serialization, journalConfig.pluginConfig.tagSeparator, journalConfig.journalTableConfiguration.writeMessageColumn)
 }
 

--- a/src/main/scala/akka/persistence/jdbc/journal/dao/ByteArrayJournalSerializer.scala
+++ b/src/main/scala/akka/persistence/jdbc/journal/dao/ByteArrayJournalSerializer.scala
@@ -20,13 +20,55 @@ package journal.dao
 import akka.actor.ActorRef
 import akka.persistence.PersistentRepr
 import akka.persistence.jdbc.serialization.FlowPersistentReprSerializer
-import akka.serialization.{ Serialization, SerializerWithStringManifest, Serializers }
+import akka.serialization.{ Serialization, Serializers }
 
 import scala.collection.immutable._
-import scala.util.{ Failure, Success, Try }
+import scala.util.{ Success, Try }
 
-class ByteArrayJournalSerializer(serialization: Serialization, separator: String, writeMessageColumn: Boolean) extends FlowPersistentReprSerializer[JournalRow] {
+class ByteArrayJournalSerializer(serialization: Serialization, separator: String) extends FlowPersistentReprSerializer[JournalRow] {
   override def serialize(persistentRepr: PersistentRepr, tags: Set[String]): Try[JournalRow] = {
+    val payload = persistentRepr.payload.asInstanceOf[AnyRef]
+    val tryEvent = serialization.serialize(payload)
+
+    for {
+      message <- serialization.serialize(persistentRepr)
+      event <- tryEvent
+    } yield {
+      val serializer = serialization.findSerializerFor(payload)
+      val serManifest = Serializers.manifestFor(serializer, payload)
+      JournalRow(
+        Long.MinValue,
+        persistentRepr.deleted,
+        persistentRepr.persistenceId,
+        persistentRepr.sequenceNr,
+        encodeTags(tags, separator),
+        event,
+        persistentRepr.manifest,
+        serializer.identifier,
+        serManifest,
+        persistentRepr.writerUuid)
+    }
+  }
+
+  override def deserialize(journalRow: JournalRow): Try[(PersistentRepr, Set[String], Long)] = {
+    serialization.deserialize(
+      journalRow.event,
+      journalRow.serId,
+      journalRow.serManifest).map { payload =>
+        (PersistentRepr(
+          payload,
+          journalRow.sequenceNumber,
+          journalRow.persistenceId,
+          journalRow.eventManifest,
+          journalRow.deleted,
+          ActorRef.noSender,
+          journalRow.writerUuid), decodeTags(journalRow.tags, separator), journalRow.ordering)
+      }
+  }
+}
+
+class LegacyByteArrayJournalSerializer(serialization: Serialization, separator: String, writeMessageColumn: Boolean) extends FlowPersistentReprSerializer[LegacyJournalRow] {
+  override def serialize(persistentRepr: PersistentRepr, tags: Set[String]): Try[LegacyJournalRow] = {
 
     val tryMessageColumn = if (writeMessageColumn) {
       serialization.serialize(persistentRepr).map(Some.apply)
@@ -42,7 +84,7 @@ class ByteArrayJournalSerializer(serialization: Serialization, separator: String
     } yield {
       val serializer = serialization.findSerializerFor(payload)
       val serManifest = Serializers.manifestFor(serializer, payload)
-      JournalRow(
+      LegacyJournalRow(
         Long.MinValue,
         persistentRepr.deleted,
         persistentRepr.persistenceId,
@@ -57,26 +99,19 @@ class ByteArrayJournalSerializer(serialization: Serialization, separator: String
     }
   }
 
-  override def deserialize(journalRow: JournalRow): Try[(PersistentRepr, Set[String], Long)] = {
-    if (journalRow.event.isDefined && journalRow.serId.isDefined) {
-      serialization.deserialize(
-        journalRow.event.get,
-        journalRow.serId.get,
-        journalRow.serManifest.getOrElse("")).map { payload =>
-          (PersistentRepr(
-            payload,
-            journalRow.sequenceNumber,
-            journalRow.persistenceId,
-            journalRow.eventManifest.getOrElse(PersistentRepr.Undefined),
-            journalRow.deleted,
-            ActorRef.noSender,
-            journalRow.writerUuid.getOrElse(PersistentRepr.Undefined)), decodeTags(journalRow.tags, separator), journalRow.ordering)
-        }
-    } else if (journalRow.message.isDefined) {
-      serialization.deserialize(journalRow.message.get, classOf[PersistentRepr])
-        .map((_, decodeTags(journalRow.tags, separator), journalRow.ordering))
-    } else {
-      Failure(new RuntimeException("Row does not define an event or message"))
-    }
+  override def deserialize(journalRow: LegacyJournalRow): Try[(PersistentRepr, Set[String], Long)] = {
+    serialization.deserialize(
+      journalRow.event.get,
+      journalRow.serId.get,
+      journalRow.serManifest.getOrElse("")).map { payload =>
+        (PersistentRepr(
+          payload,
+          journalRow.sequenceNumber,
+          journalRow.persistenceId,
+          journalRow.eventManifest.getOrElse(PersistentRepr.Undefined),
+          journalRow.deleted,
+          ActorRef.noSender,
+          journalRow.writerUuid.getOrElse(PersistentRepr.Undefined)), decodeTags(journalRow.tags, separator), journalRow.ordering)
+      }
   }
 }

--- a/src/main/scala/akka/persistence/jdbc/journal/dao/ByteArrayJournalSerializer.scala
+++ b/src/main/scala/akka/persistence/jdbc/journal/dao/ByteArrayJournalSerializer.scala
@@ -20,13 +20,55 @@ package journal.dao
 import akka.actor.ActorRef
 import akka.persistence.PersistentRepr
 import akka.persistence.jdbc.serialization.FlowPersistentReprSerializer
-import akka.serialization.{ Serialization, SerializerWithStringManifest, Serializers }
+import akka.serialization.{ Serialization, Serializers }
 
 import scala.collection.immutable._
-import scala.util.{ Failure, Success, Try }
+import scala.util.{ Success, Try }
 
-class ByteArrayJournalSerializer(serialization: Serialization, separator: String, writeMessageColumn: Boolean) extends FlowPersistentReprSerializer[JournalRow] {
+class ByteArrayJournalSerializer(serialization: Serialization, separator: String) extends FlowPersistentReprSerializer[JournalRow] {
   override def serialize(persistentRepr: PersistentRepr, tags: Set[String]): Try[JournalRow] = {
+    val payload = persistentRepr.payload.asInstanceOf[AnyRef]
+    val tryEvent = serialization.serialize(payload)
+
+    for {
+      message <- serialization.serialize(persistentRepr)
+      event <- tryEvent
+    } yield {
+      val serializer = serialization.findSerializerFor(payload)
+      val serManifest = Serializers.manifestFor(serializer, payload)
+      JournalRow(
+        Long.MinValue,
+        persistentRepr.deleted,
+        persistentRepr.persistenceId,
+        persistentRepr.sequenceNr,
+        encodeTags(tags, separator),
+        event,
+        Some(persistentRepr.manifest),
+        serializer.identifier,
+        Some(serManifest),
+        persistentRepr.writerUuid)
+    }
+  }
+
+  override def deserialize(journalRow: JournalRow): Try[(PersistentRepr, Set[String], Long)] = {
+    serialization.deserialize(
+      journalRow.event,
+      journalRow.serId,
+      journalRow.serManifest.getOrElse("")).map { payload =>
+        (PersistentRepr(
+          payload,
+          journalRow.sequenceNumber,
+          journalRow.persistenceId,
+          journalRow.eventManifest.getOrElse(PersistentRepr.Undefined),
+          journalRow.deleted,
+          ActorRef.noSender,
+          journalRow.writerUuid), decodeTags(journalRow.tags, separator), journalRow.ordering)
+      }
+  }
+}
+
+class LegacyByteArrayJournalSerializer(serialization: Serialization, separator: String, writeMessageColumn: Boolean) extends FlowPersistentReprSerializer[LegacyJournalRow] {
+  override def serialize(persistentRepr: PersistentRepr, tags: Set[String]): Try[LegacyJournalRow] = {
 
     val tryMessageColumn = if (writeMessageColumn) {
       serialization.serialize(persistentRepr).map(Some.apply)
@@ -42,7 +84,7 @@ class ByteArrayJournalSerializer(serialization: Serialization, separator: String
     } yield {
       val serializer = serialization.findSerializerFor(payload)
       val serManifest = Serializers.manifestFor(serializer, payload)
-      JournalRow(
+      LegacyJournalRow(
         Long.MinValue,
         persistentRepr.deleted,
         persistentRepr.persistenceId,
@@ -57,26 +99,19 @@ class ByteArrayJournalSerializer(serialization: Serialization, separator: String
     }
   }
 
-  override def deserialize(journalRow: JournalRow): Try[(PersistentRepr, Set[String], Long)] = {
-    if (journalRow.event.isDefined && journalRow.serId.isDefined) {
-      serialization.deserialize(
-        journalRow.event.get,
-        journalRow.serId.get,
-        journalRow.serManifest.getOrElse("")).map { payload =>
-          (PersistentRepr(
-            payload,
-            journalRow.sequenceNumber,
-            journalRow.persistenceId,
-            journalRow.eventManifest.getOrElse(PersistentRepr.Undefined),
-            journalRow.deleted,
-            ActorRef.noSender,
-            journalRow.writerUuid.getOrElse(PersistentRepr.Undefined)), decodeTags(journalRow.tags, separator), journalRow.ordering)
-        }
-    } else if (journalRow.message.isDefined) {
-      serialization.deserialize(journalRow.message.get, classOf[PersistentRepr])
-        .map((_, decodeTags(journalRow.tags, separator), journalRow.ordering))
-    } else {
-      Failure(new RuntimeException("Row does not define an event or message"))
-    }
+  override def deserialize(journalRow: LegacyJournalRow): Try[(PersistentRepr, Set[String], Long)] = {
+    serialization.deserialize(
+      journalRow.event.get,
+      journalRow.serId.get,
+      journalRow.serManifest.getOrElse("")).map { payload =>
+        (PersistentRepr(
+          payload,
+          journalRow.sequenceNumber,
+          journalRow.persistenceId,
+          journalRow.eventManifest.getOrElse(PersistentRepr.Undefined),
+          journalRow.deleted,
+          ActorRef.noSender,
+          journalRow.writerUuid.getOrElse(PersistentRepr.Undefined)), decodeTags(journalRow.tags, separator), journalRow.ordering)
+      }
   }
 }

--- a/src/main/scala/akka/persistence/jdbc/journal/dao/ByteArrayJournalSerializer.scala
+++ b/src/main/scala/akka/persistence/jdbc/journal/dao/ByteArrayJournalSerializer.scala
@@ -20,10 +20,10 @@ package journal.dao
 import akka.actor.ActorRef
 import akka.persistence.PersistentRepr
 import akka.persistence.jdbc.serialization.FlowPersistentReprSerializer
-import akka.serialization.{Serialization, SerializerWithStringManifest, Serializers}
+import akka.serialization.{ Serialization, SerializerWithStringManifest, Serializers }
 
 import scala.collection.immutable._
-import scala.util.{Failure, Success, Try}
+import scala.util.{ Failure, Success, Try }
 
 class ByteArrayJournalSerializer(serialization: Serialization, separator: String, writeMessageColumn: Boolean) extends FlowPersistentReprSerializer[JournalRow] {
   override def serialize(persistentRepr: PersistentRepr, tags: Set[String]): Try[JournalRow] = {

--- a/src/main/scala/akka/persistence/jdbc/journal/dao/JournalQueries.scala
+++ b/src/main/scala/akka/persistence/jdbc/journal/dao/JournalQueries.scala
@@ -18,12 +18,38 @@ package akka.persistence.jdbc
 package journal.dao
 
 import akka.persistence.jdbc.config.JournalTableConfiguration
+
 import slick.jdbc.JdbcProfile
 import slick.sql.FixedSqlAction
 
-class JournalQueries(val profile: JdbcProfile, override val journalTableCfg: JournalTableConfiguration) extends JournalTables {
+trait GenericQueries {
+  import slick.dbio.Effect
+  val profile: JdbcProfile
+  import profile.api._
+  def writeJournalRows(xs: Seq[JournalRow]): FixedSqlAction[Option[Int], NoStream, Effect.Write]
+  def delete(persistenceId: String, toSequenceNr: Long): FixedSqlAction[Int, NoStream, Effect.Write]
+  def update(persistenceId: String, seqNr: Long, newRow: JournalRow): FixedSqlAction[Int, NoStream, Effect.Write]
+  def markJournalMessagesAsDeleted(persistenceId: String, maxSequenceNr: Long): FixedSqlAction[Int, NoStream, Effect.Write]
+  def journalRowByPersistenceIds(persistenceIds: Iterable[String]): Query[Rep[String], String, Seq]
+}
+
+class LegacyJournalQueries(val profile: JdbcProfile, override val journalTableCfg: JournalTableConfiguration) extends LegacyJournalTables with GenericQueries {
+  import profile.api._
+  private val JournalTableC = Compiled(JournalTable)
+  import slick.dbio.Effect
+  def writeJournalRows(xs: Seq[JournalRow]): FixedSqlAction[Option[Int], NoStream, Effect.Write] = ???
+  def delete(persistenceId: String, toSequenceNr: Long): FixedSqlAction[Int, NoStream, Effect.Write] = ???
+  def update(persistenceId: String, seqNr: Long, newRow: JournalRow): FixedSqlAction[Int, NoStream, Effect.Write] = ???
+  def markJournalMessagesAsDeleted(persistenceId: String, maxSequenceNr: Long): FixedSqlAction[Int, NoStream, Effect.Write] = ???
+  def journalRowByPersistenceIds(persistenceIds: Iterable[String]): Query[Rep[String], String, Seq] = ???
+
+}
+
+class JournalQueries(val profile: JdbcProfile, override val journalTableCfg: JournalTableConfiguration) extends JournalTables with GenericQueries {
 
   import profile.api._
+
+  import slick.dbio.Effect
 
   private val JournalTableC = Compiled(JournalTable)
 
@@ -33,7 +59,7 @@ class JournalQueries(val profile: JdbcProfile, override val journalTableCfg: Jou
   private def selectAllJournalForPersistenceId(persistenceId: Rep[String]) =
     JournalTable.filter(_.persistenceId === persistenceId).sortBy(_.sequenceNumber.desc)
 
-  def delete(persistenceId: String, toSequenceNr: Long) = {
+  def delete(persistenceId: String, toSequenceNr: Long): FixedSqlAction[Int, NoStream, Effect.Write] = {
     JournalTable
       .filter(_.persistenceId === persistenceId)
       .filter(_.sequenceNumber <= toSequenceNr)
@@ -44,19 +70,15 @@ class JournalQueries(val profile: JdbcProfile, override val journalTableCfg: Jou
    * Updates (!) a payload stored in a specific events row.
    * Intended to be used sparingly, e.g. moving all events to their encrypted counterparts.
    */
-  def update(persistenceId: String, seqNr: Long, replacementMessage: Option[Array[Byte]], replacementEvent: Option[Array[Byte]], replacementSerId: Option[Int], replacementSerManifest: Option[String]): FixedSqlAction[Int, NoStream, Effect.Write] = {
+  def update(persistenceId: String, seqNr: Long, newRow: JournalRow): FixedSqlAction[Int, NoStream, Effect.Write] = {
     val baseQuery = JournalTable
       .filter(_.persistenceId === persistenceId)
       .filter(_.sequenceNumber === seqNr)
 
-    if (replacementMessage.isDefined) {
-      baseQuery.map(row => (row.message, row.event, row.serId, row.serManifest)).update((replacementMessage, replacementEvent, replacementSerId, replacementSerManifest))
-    } else {
-      baseQuery.map(row => (row.event, row.serId, row.serManifest)).update((replacementEvent, replacementSerId, replacementSerManifest))
-    }
+    baseQuery.map(row => (row.event, row.serId, row.serManifest)).update((newRow.event, newRow.serId, newRow.serManifest))
   }
 
-  def markJournalMessagesAsDeleted(persistenceId: String, maxSequenceNr: Long) =
+  def markJournalMessagesAsDeleted(persistenceId: String, maxSequenceNr: Long): FixedSqlAction[Int, NoStream, Effect.Write] =
     JournalTable
       .filter(_.persistenceId === persistenceId)
       .filter(_.sequenceNumber <= maxSequenceNr)

--- a/src/main/scala/akka/persistence/jdbc/journal/dao/JournalQueries.scala
+++ b/src/main/scala/akka/persistence/jdbc/journal/dao/JournalQueries.scala
@@ -17,76 +17,170 @@
 package akka.persistence.jdbc
 package journal.dao
 
+import akka.NotUsed
 import akka.persistence.jdbc.config.JournalTableConfiguration
+import akka.stream.Materializer
+import akka.stream.scaladsl.Source
+import slick.dbio.NoStream
+import slick.jdbc.JdbcBackend.Database
 import slick.jdbc.JdbcProfile
 import slick.sql.FixedSqlAction
 
-class JournalQueries(val profile: JdbcProfile, override val journalTableCfg: JournalTableConfiguration) extends JournalTables {
+import scala.collection.immutable.Seq
+import scala.concurrent.{ ExecutionContext, Future }
 
+class GenericJournalQueries(val profile: JdbcProfile, override val journalTableCfg: JournalTableConfiguration) extends JournalTables {
   import profile.api._
 
-  private val JournalTableC = Compiled(JournalTable)
-
-  def writeJournalRows(xs: Seq[JournalRow]) =
-    JournalTableC ++= xs.sortBy(_.sequenceNumber)
-
   private def selectAllJournalForPersistenceId(persistenceId: Rep[String]) =
-    JournalTable.filter(_.persistenceId === persistenceId).sortBy(_.sequenceNumber.desc)
-
-  def delete(persistenceId: String, toSequenceNr: Long) = {
-    JournalTable
-      .filter(_.persistenceId === persistenceId)
-      .filter(_.sequenceNumber <= toSequenceNr)
-      .delete
-  }
-
-  /**
-   * Updates (!) a payload stored in a specific events row.
-   * Intended to be used sparingly, e.g. moving all events to their encrypted counterparts.
-   */
-  def update(persistenceId: String, seqNr: Long, replacementMessage: Option[Array[Byte]], replacementEvent: Option[Array[Byte]], replacementSerId: Option[Int], replacementSerManifest: Option[String]): FixedSqlAction[Int, NoStream, Effect.Write] = {
-    val baseQuery = JournalTable
-      .filter(_.persistenceId === persistenceId)
-      .filter(_.sequenceNumber === seqNr)
-
-    if (replacementMessage.isDefined) {
-      baseQuery.map(row => (row.message, row.event, row.serId, row.serManifest)).update((replacementMessage, replacementEvent, replacementSerId, replacementSerManifest))
-    } else {
-      baseQuery.map(row => (row.event, row.serId, row.serManifest)).update((replacementEvent, replacementSerId, replacementSerManifest))
-    }
-  }
+    GenericJournalTable.filter(_.persistenceId === persistenceId).sortBy(_.sequenceNumber.desc)
 
   def markJournalMessagesAsDeleted(persistenceId: String, maxSequenceNr: Long) =
-    JournalTable
+    GenericJournalTable
       .filter(_.persistenceId === persistenceId)
       .filter(_.sequenceNumber <= maxSequenceNr)
       .filter(_.deleted === false)
-      .map(_.deleted).update(true)
+      .map(_.deleted)
+      .update(true)
 
-  private def _highestSequenceNrForPersistenceId(persistenceId: Rep[String]): Query[Rep[Long], Long, Seq] =
+  private def _highestSequenceNrForPersistenceId(persistenceId: Rep[String]) =
     selectAllJournalForPersistenceId(persistenceId).map(_.sequenceNumber).take(1)
 
-  private def _highestMarkedSequenceNrForPersistenceId(persistenceId: Rep[String]): Query[Rep[Long], Long, Seq] =
+  private def _highestMarkedSequenceNrForPersistenceId(persistenceId: Rep[String]) =
     selectAllJournalForPersistenceId(persistenceId).filter(_.deleted === true).map(_.sequenceNumber)
 
   val highestSequenceNrForPersistenceId = Compiled(_highestSequenceNrForPersistenceId _)
 
   val highestMarkedSequenceNrForPersistenceId = Compiled(_highestMarkedSequenceNrForPersistenceId _)
 
-  private def _selectByPersistenceIdAndMaxSequenceNumber(persistenceId: Rep[String], maxSequenceNr: Rep[Long]) =
-    selectAllJournalForPersistenceId(persistenceId).filter(_.sequenceNumber <= maxSequenceNr)
-
-  val selectByPersistenceIdAndMaxSequenceNumber = Compiled(_selectByPersistenceIdAndMaxSequenceNumber _)
-
-  private def _allPersistenceIdsDistinct: Query[Rep[String], String, Seq] =
-    JournalTable.map(_.persistenceId).distinct
+  private def _allPersistenceIdsDistinct =
+    GenericJournalTable.map(_.persistenceId).distinct
 
   val allPersistenceIdsDistinct = Compiled(_allPersistenceIdsDistinct)
 
-  def journalRowByPersistenceIds(persistenceIds: Iterable[String]): Query[Rep[String], String, Seq] = for {
-    query <- JournalTable.map(_.persistenceId)
+  def journalRowByPersistenceIds(persistenceIds: Iterable[String]) = for {
+    query <- GenericJournalTable.map(_.persistenceId)
     if query inSetBind persistenceIds
   } yield query
+
+}
+
+trait JournalQueries[T <: AbstractJournalRow] {
+  import slick.dbio.Effect
+  implicit val ec: ExecutionContext
+  implicit val mat: Materializer
+
+  def writeJournalRows(xs: Seq[T]): Future[Unit]
+  def delete(persistenceId: String, toSequenceNr: Long): FixedSqlAction[Int, NoStream, Effect.Write]
+  def messages(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long): Source[T, NotUsed]
+  def update(persistenceId: String, seqNr: Long, row: T): Future[Int]
+  val db: Database
+}
+
+class LegacyJournalQueries(
+    val db: Database,
+    val profile: JdbcProfile,
+    override val journalTableCfg: JournalTableConfiguration)(implicit val ec: ExecutionContext, val mat: Materializer)
+  extends JournalTables with JournalQueries[LegacyJournalRow] {
+  import profile.api._
+  import slick.dbio.Effect
+
+  def writeJournalRows(xs: Seq[LegacyJournalRow]): Future[Unit] = {
+    for {
+      _ <- db.run(LegacyJournalTable ++= xs.sortBy(_.sequenceNumber))
+    } yield ()
+  }
+
+  def update(persistenceId: String, seqNr: Long, row: LegacyJournalRow): Future[Int] = {
+    val q = {
+      val baseQuery = LegacyJournalTable
+        .filter(_.persistenceId === persistenceId)
+        .filter(_.sequenceNumber === seqNr)
+
+      baseQuery.map(row => (row.message, row.event, row.serId, row.serManifest)).update((row.message, row.event, row.serId, row.serManifest))
+    }
+    db.run(q)
+  }
+
+  def delete(persistenceId: String, toSequenceNr: Long): FixedSqlAction[Int, NoStream, Effect.Write] = {
+    LegacyJournalTable
+      .filter(_.persistenceId === persistenceId)
+      .filter(_.sequenceNumber <= toSequenceNr)
+      .delete
+  }
+
+  override def messages(
+    persistenceId: String,
+    fromSequenceNr: Long,
+    toSequenceNr: Long,
+    max: Long): Source[LegacyJournalRow, NotUsed] = Source.fromPublisher(db.stream(messagesQuery(persistenceId, fromSequenceNr, toSequenceNr, max).result))
+
+  private def updateJournalTable(persistenceId: String, seqNr: Long, replacementMessage: Option[Array[Byte]], replacementEvent: Option[Array[Byte]], replacementSerId: Option[Int], replacementSerManifest: Option[String]): FixedSqlAction[Int, NoStream, Effect.Write] = {
+    val baseQuery = LegacyJournalTable
+      .filter(_.persistenceId === persistenceId)
+      .filter(_.sequenceNumber === seqNr)
+
+    baseQuery.map(row => (row.message, row.event, row.serId, row.serManifest)).update((replacementMessage, replacementEvent, replacementSerId, replacementSerManifest))
+  }
+
+  private def _messagesQuery(persistenceId: Rep[String], fromSequenceNr: Rep[Long], toSequenceNr: Rep[Long], max: ConstColumn[Long]) =
+    LegacyJournalTable
+      .filter(_.persistenceId === persistenceId)
+      .filter(_.deleted === false)
+      .filter(_.sequenceNumber >= fromSequenceNr)
+      .filter(_.sequenceNumber <= toSequenceNr)
+      .sortBy(_.sequenceNumber.asc)
+      .take(max)
+
+  private val messagesQuery = Compiled(_messagesQuery _)
+
+}
+
+class NewJournalQueries(
+    val db: Database,
+    val profile: JdbcProfile,
+    override val journalTableCfg: JournalTableConfiguration)(implicit val ec: ExecutionContext, val mat: Materializer)
+  extends JournalTables with JournalQueries[JournalRow] {
+
+  import profile.api._
+
+  private val JournalTableC = Compiled(JournalTable)
+
+  def writeJournalRows(xs: Seq[JournalRow]): Future[Unit] = {
+    for {
+      _ <- db.run(JournalTable ++= xs.sortBy(_.sequenceNumber))
+    } yield ()
+  }
+
+  def messages(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long): Source[JournalRow, NotUsed] = {
+    Source.fromPublisher(db.stream(messagesQuery(persistenceId, fromSequenceNr, toSequenceNr, max).result))
+  }
+
+  def update(persistenceId: String, seqNr: Long, row: JournalRow): Future[Int] = {
+    val q = {
+      val baseQuery = JournalTable
+        .filter(_.persistenceId === persistenceId)
+        .filter(_.sequenceNumber === seqNr)
+
+      baseQuery.map(row => (row.event, row.serId, row.serManifest)).update((row.event, row.serId, row.serManifest))
+    }
+    db.run(q)
+  }
+
+  def delete(persistenceId: String, toSequenceNr: Long): FixedSqlAction[Int, NoStream, Effect.Write] = {
+    JournalTable
+      .filter(_.persistenceId === persistenceId)
+      .filter(_.sequenceNumber <= toSequenceNr)
+      .delete
+  }
+
+  private def updateJournalTable(persistenceId: String, seqNr: Long, replacementEvent: Array[Byte], replacementSerId: Int, replacementSerManifest: Option[String]) = {
+    val baseQuery = JournalTable
+      .filter(_.persistenceId === persistenceId)
+      .filter(_.sequenceNumber === seqNr)
+
+    baseQuery.map(row => (row.event, row.serId, row.serManifest)).update((replacementEvent, replacementSerId, replacementSerManifest))
+  }
 
   private def _messagesQuery(persistenceId: Rep[String], fromSequenceNr: Rep[Long], toSequenceNr: Rep[Long], max: ConstColumn[Long]) =
     JournalTable
@@ -97,6 +191,6 @@ class JournalQueries(val profile: JdbcProfile, override val journalTableCfg: Jou
       .sortBy(_.sequenceNumber.asc)
       .take(max)
 
-  val messagesQuery = Compiled(_messagesQuery _)
+  private val messagesQuery = Compiled(_messagesQuery _)
 
 }

--- a/src/main/scala/akka/persistence/jdbc/journal/dao/JournalTables.scala
+++ b/src/main/scala/akka/persistence/jdbc/journal/dao/JournalTables.scala
@@ -27,18 +27,39 @@ trait JournalTables {
 
   def journalTableCfg: JournalTableConfiguration
 
-  class Journal(_tableTag: Tag) extends Table[JournalRow](_tableTag, _schemaName = journalTableCfg.schemaName, _tableName = journalTableCfg.tableName) {
-    def * : ProvenShape[JournalRow] = if (journalTableCfg.hasMessageColumn) {
-      (ordering, deleted, persistenceId, sequenceNumber, message, tags, event, eventManifest, serId, serManifest, writerUuid) <> (JournalRow.tupled, JournalRow.unapply)
-    } else {
-      (ordering, deleted, persistenceId, sequenceNumber, tags, event, eventManifest, serId, serManifest, writerUuid) <> ({
-        case (ordering, deleted, persistenceId, sequenceNumber, tags, event, eventManifest, serId, serManifest, writerUuid) =>
-          JournalRow(ordering, deleted, persistenceId, sequenceNumber, None, tags, event, eventManifest, serId, serManifest, writerUuid)
-      },
-        (row: JournalRow) => {
-          Some((row.ordering, row.deleted, row.persistenceId, row.sequenceNumber, row.tags, row.event, row.eventManifest, row.serId, row.serManifest, row.writerUuid))
-        })
-    }
+  trait GenericJournalTable { this: Table[_ <: AbstractJournalRow] =>
+    def ordering: Rep[Long]
+    def persistenceId: Rep[String]
+    def sequenceNumber: Rep[Long]
+    def deleted: Rep[Boolean]
+    def tags: Rep[Option[String]]
+  }
+
+  class Journal(_tableTag: Tag) extends Table[JournalRow](_tableTag, _schemaName = journalTableCfg.schemaName, _tableName = journalTableCfg.tableName) with GenericJournalTable {
+    def * : ProvenShape[JournalRow] =
+      (ordering, deleted, persistenceId, sequenceNumber, tags, event, eventManifest, serId, serManifest, writerUuid) <> (JournalRow.tupled, JournalRow.unapply)
+
+    val ordering: Rep[Long] = column[Long](journalTableCfg.columnNames.ordering, O.AutoInc)
+    val persistenceId: Rep[String] = column[String](journalTableCfg.columnNames.persistenceId, O.Length(255, varying = true))
+    val sequenceNumber: Rep[Long] = column[Long](journalTableCfg.columnNames.sequenceNumber)
+    val deleted: Rep[Boolean] = column[Boolean](journalTableCfg.columnNames.deleted, O.Default(false))
+    val tags: Rep[Option[String]] = column[Option[String]](journalTableCfg.columnNames.tags, O.Length(255, varying = true))
+
+    val event: Rep[Array[Byte]] = column[Array[Byte]](journalTableCfg.columnNames.event)
+    val eventManifest: Rep[Option[String]] = column[Option[String]](journalTableCfg.columnNames.eventManifest, O.Length(255, varying = true))
+    val serId: Rep[Int] = column[Int](journalTableCfg.columnNames.serId)
+    val serManifest: Rep[Option[String]] = column[Option[String]](journalTableCfg.columnNames.serManifest, O.Length(255, varying = true))
+    val writerUuid: Rep[String] = column[String](journalTableCfg.columnNames.writerUuid, O.Length(36, varying = true))
+
+    val pk = primaryKey(s"${tableName}_pk", (persistenceId, sequenceNumber))
+    val orderingIdx = index(s"${tableName}_ordering_idx", ordering, unique = true)
+  }
+
+  lazy val JournalTable: TableQuery[Journal] = new TableQuery(tag => new Journal(tag))
+
+  class LegacyJournal(_tableTag: Tag) extends Table[LegacyJournalRow](_tableTag, _schemaName = journalTableCfg.schemaName, _tableName = journalTableCfg.tableName) with GenericJournalTable {
+    def * : ProvenShape[LegacyJournalRow] =
+      (ordering, deleted, persistenceId, sequenceNumber, message, tags, event, eventManifest, serId, serManifest, writerUuid) <> (LegacyJournalRow.tupled, LegacyJournalRow.unapply)
 
     val ordering: Rep[Long] = column[Long](journalTableCfg.columnNames.ordering, O.AutoInc)
     val persistenceId: Rep[String] = column[String](journalTableCfg.columnNames.persistenceId, O.Length(255, varying = true))
@@ -58,5 +79,9 @@ trait JournalTables {
     val orderingIdx = index(s"${tableName}_ordering_idx", ordering, unique = true)
   }
 
-  lazy val JournalTable = new TableQuery(tag => new Journal(tag))
+  lazy val LegacyJournalTable: TableQuery[LegacyJournal] = new TableQuery(tag => new LegacyJournal(tag))
+
+  lazy val GenericJournalTable: Query[GenericJournalTable, _ <: AbstractJournalRow, Seq] =
+    if (journalTableCfg.hasMessageColumn) LegacyJournalTable else JournalTable
+
 }

--- a/src/main/scala/akka/persistence/jdbc/journal/dao/JournalTables.scala
+++ b/src/main/scala/akka/persistence/jdbc/journal/dao/JournalTables.scala
@@ -20,12 +20,45 @@ package journal.dao
 import akka.persistence.jdbc.config.JournalTableConfiguration
 import slick.lifted.ProvenShape
 
-trait JournalTables {
+trait AbstractJournalTables {
   val profile: slick.jdbc.JdbcProfile
 
-  import profile.api._
-
   def journalTableCfg: JournalTableConfiguration
+
+}
+
+trait LegacyJournalTables extends AbstractJournalTables {
+  import profile.api._
+  @deprecated("This was used to store the the PersistentRepr serialized as is, but no longer.", "4.0.0")
+  class Journal(_tableTag: Tag) extends Table[LegacyJournalRow](_tableTag, _schemaName = journalTableCfg.schemaName, _tableName = journalTableCfg.tableName) {
+    def * : ProvenShape[LegacyJournalRow] = (ordering, deleted, persistenceId, sequenceNumber, tags, event, eventManifest, serId, serManifest, writerUuid) <> ({
+      case (ordering, deleted, persistenceId, sequenceNumber, tags, event, eventManifest, serId, serManifest, writerUuid) =>
+        LegacyJournalRow(ordering, deleted, persistenceId, sequenceNumber, None, tags, event, eventManifest, serId, serManifest, writerUuid)
+    },
+      (row: LegacyJournalRow) => {
+        Some((row.ordering, row.deleted, row.persistenceId, row.sequenceNumber, row.tags, row.event, row.eventManifest, row.serId, row.serManifest, row.writerUuid))
+      })
+
+    val ordering: Rep[Long] = column[Long](journalTableCfg.columnNames.ordering, O.AutoInc)
+    val persistenceId: Rep[String] = column[String](journalTableCfg.columnNames.persistenceId, O.Length(255, varying = true))
+    val sequenceNumber: Rep[Long] = column[Long](journalTableCfg.columnNames.sequenceNumber)
+    val deleted: Rep[Boolean] = column[Boolean](journalTableCfg.columnNames.deleted, O.Default(false))
+    val tags: Rep[Option[String]] = column[Option[String]](journalTableCfg.columnNames.tags, O.Length(255, varying = true))
+    val message: Rep[Option[Array[Byte]]] = column[Array[Byte]](journalTableCfg.columnNames.message)
+    val event: Rep[Option[Array[Byte]]] = column[Option[Array[Byte]]](journalTableCfg.columnNames.event)
+    val eventManifest: Rep[Option[String]] = column[Option[String]](journalTableCfg.columnNames.eventManifest, O.Length(255, varying = true))
+    val serId: Rep[Option[Int]] = column[Option[Int]](journalTableCfg.columnNames.serId)
+    val serManifest: Rep[Option[String]] = column[Option[String]](journalTableCfg.columnNames.serManifest, O.Length(255, varying = true))
+    val writerUuid: Rep[Option[String]] = column[Option[String]](journalTableCfg.columnNames.writerUuid, O.Length(36, varying = true))
+
+    val pk = primaryKey(s"${tableName}_pk", (persistenceId, sequenceNumber))
+    val orderingIdx = index(s"${tableName}_ordering_idx", ordering, unique = true)
+  }
+  lazy val JournalTable = new TableQuery(tag => new Journal(tag))
+}
+
+trait JournalTables extends AbstractJournalTables {
+  import profile.api._
 
   class Journal(_tableTag: Tag) extends Table[JournalRow](_tableTag, _schemaName = journalTableCfg.schemaName, _tableName = journalTableCfg.tableName) {
     def * : ProvenShape[JournalRow] = if (journalTableCfg.hasMessageColumn) {

--- a/src/main/scala/akka/persistence/jdbc/journal/dao/JournalTables.scala
+++ b/src/main/scala/akka/persistence/jdbc/journal/dao/JournalTables.scala
@@ -20,45 +20,12 @@ package journal.dao
 import akka.persistence.jdbc.config.JournalTableConfiguration
 import slick.lifted.ProvenShape
 
-trait AbstractJournalTables {
+trait JournalTables {
   val profile: slick.jdbc.JdbcProfile
 
+  import profile.api._
+
   def journalTableCfg: JournalTableConfiguration
-
-}
-
-trait LegacyJournalTables extends AbstractJournalTables {
-  import profile.api._
-  @deprecated("This was used to store the the PersistentRepr serialized as is, but no longer.", "4.0.0")
-  class Journal(_tableTag: Tag) extends Table[LegacyJournalRow](_tableTag, _schemaName = journalTableCfg.schemaName, _tableName = journalTableCfg.tableName) {
-    def * : ProvenShape[LegacyJournalRow] = (ordering, deleted, persistenceId, sequenceNumber, tags, event, eventManifest, serId, serManifest, writerUuid) <> ({
-      case (ordering, deleted, persistenceId, sequenceNumber, tags, event, eventManifest, serId, serManifest, writerUuid) =>
-        LegacyJournalRow(ordering, deleted, persistenceId, sequenceNumber, None, tags, event, eventManifest, serId, serManifest, writerUuid)
-    },
-      (row: LegacyJournalRow) => {
-        Some((row.ordering, row.deleted, row.persistenceId, row.sequenceNumber, row.tags, row.event, row.eventManifest, row.serId, row.serManifest, row.writerUuid))
-      })
-
-    val ordering: Rep[Long] = column[Long](journalTableCfg.columnNames.ordering, O.AutoInc)
-    val persistenceId: Rep[String] = column[String](journalTableCfg.columnNames.persistenceId, O.Length(255, varying = true))
-    val sequenceNumber: Rep[Long] = column[Long](journalTableCfg.columnNames.sequenceNumber)
-    val deleted: Rep[Boolean] = column[Boolean](journalTableCfg.columnNames.deleted, O.Default(false))
-    val tags: Rep[Option[String]] = column[Option[String]](journalTableCfg.columnNames.tags, O.Length(255, varying = true))
-    val message: Rep[Option[Array[Byte]]] = column[Array[Byte]](journalTableCfg.columnNames.message)
-    val event: Rep[Option[Array[Byte]]] = column[Option[Array[Byte]]](journalTableCfg.columnNames.event)
-    val eventManifest: Rep[Option[String]] = column[Option[String]](journalTableCfg.columnNames.eventManifest, O.Length(255, varying = true))
-    val serId: Rep[Option[Int]] = column[Option[Int]](journalTableCfg.columnNames.serId)
-    val serManifest: Rep[Option[String]] = column[Option[String]](journalTableCfg.columnNames.serManifest, O.Length(255, varying = true))
-    val writerUuid: Rep[Option[String]] = column[Option[String]](journalTableCfg.columnNames.writerUuid, O.Length(36, varying = true))
-
-    val pk = primaryKey(s"${tableName}_pk", (persistenceId, sequenceNumber))
-    val orderingIdx = index(s"${tableName}_ordering_idx", ordering, unique = true)
-  }
-  lazy val JournalTable = new TableQuery(tag => new Journal(tag))
-}
-
-trait JournalTables extends AbstractJournalTables {
-  import profile.api._
 
   class Journal(_tableTag: Tag) extends Table[JournalRow](_tableTag, _schemaName = journalTableCfg.schemaName, _tableName = journalTableCfg.tableName) {
     def * : ProvenShape[JournalRow] = if (journalTableCfg.hasMessageColumn) {

--- a/src/main/scala/akka/persistence/jdbc/migraition/V4Migration.scala
+++ b/src/main/scala/akka/persistence/jdbc/migraition/V4Migration.scala
@@ -15,6 +15,7 @@ import scala.util.{ Failure, Success }
 class V4JournalMigration(config: Config, system: ActorSystem) extends JournalTables {
 
   private val journalConfig = new JournalConfig(config)
+  private val log = system.log
 
   if (!journalConfig.journalTableConfiguration.hasMessageColumn) {
     throw new IllegalArgumentException("Journal table configuration does not have message column, cannot perform migration.")
@@ -38,32 +39,47 @@ class V4JournalMigration(config: Config, system: ActorSystem) extends JournalTab
   def run(): Unit = {
     val db = SlickDatabase.forConfig(config, journalConfig.slickConfiguration)
     try {
-      println(s"Migrating journal events, each . indicates $RowsPerTransaction rows migrated.")
-      val migration = migrateNextBatch(db, 0)
-      val migrated = Await.result(migration, Duration.Inf)
-      println(s"Journal migration complete! $migrated events were migrated.")
+      val migration = for {
+        eventsToMigrate <- countEventsToMigrate(db)
+        _ = log.info(s"Migrating $eventsToMigrate journal events in batches of $RowsPerTransaction.")
+        migrated <- migrateNextBatch(db, migrated = 0, orderingFrom = 0L)
+      } yield {
+        log.info(s"Journal migration complete! $migrated events were migrated.")
+      }
+      Await.result(migration, Duration.Inf)
     } finally {
       db.close()
     }
   }
 
-  private def migrateNextBatch(db: Database, migrated: Long): Future[Long] = {
-    migrateJournalBatch(db).flatMap {
-      case 0 =>
-        println(" done!")
+  private def migrateNextBatch(db: Database, migrated: Int, orderingFrom: Long): Future[Int] = {
+    migrateJournalBatch(db, orderingFrom).flatMap {
+      case (_, None) =>
+        log.info("done!")
         Future.successful(migrated)
-      case batch =>
-        print(".")
-        migrateNextBatch(db, migrated + batch)
+      case (batch, Some(maxHandledOrdering)) =>
+        log.info(s"$batch events have been migrated, max(ordering)=$maxHandledOrdering")
+        migrateNextBatch(db, migrated + batch, maxHandledOrdering)
     }
   }
 
-  private def migrateJournalBatch(db: Database): Future[Int] = {
+  private def countEventsToMigrate(db: Database) = {
+    val query = JournalTable
+      .filter(_.serId.isEmpty)
+      .length
+      .result
+    db.run(query)
+  }
+
+  private def migrateJournalBatch(db: Database, orderingFrom: Long): Future[(Int, Option[Long])] = {
     val batchUpdate = JournalTable
-      .filter(_.event.isEmpty)
+      .filter(_.serId.isEmpty)
+      .filter(_.ordering > orderingFrom)
+      .sortBy(_.ordering.asc)
       .take(RowsPerTransaction)
       .result
       .flatMap(rows => {
+        val maxHandledOrdering: Option[Long] = if (rows.nonEmpty) Some(rows.map(_.ordering).max) else None
         val updates = rows.map { row =>
           val migration = serializer.deserialize(row).flatMap {
             case (pr, tags, _) =>
@@ -80,7 +96,7 @@ class V4JournalMigration(config: Config, system: ActorSystem) extends JournalTab
               throw new RuntimeException(s"Migration of event with persistence id ${row.persistenceId} and sequence number ${row.sequenceNumber} failed", error)
           }
         }
-        DBIO.seq(updates: _*).map(_ => updates.size)
+        DBIO.seq(updates: _*).map(_ => (updates.size, maxHandledOrdering))
       })
 
     db.run(batchUpdate)
@@ -88,6 +104,7 @@ class V4JournalMigration(config: Config, system: ActorSystem) extends JournalTab
 }
 
 class V4SnapshotMigration(config: Config, system: ActorSystem) extends SnapshotTables {
+  private val log = system.log
 
   private val snapshotConfig = new SnapshotConfig(config)
 
@@ -112,32 +129,47 @@ class V4SnapshotMigration(config: Config, system: ActorSystem) extends SnapshotT
   def run(): Unit = {
     val db = SlickDatabase.forConfig(config, snapshotConfig.slickConfiguration)
     try {
-      println(s"Migrating snapshots, each . indicates $RowsPerTransaction rows migrated.")
-      val migration = migrateNextBatch(db, 0)
-      val migrated = Await.result(migration, Duration.Inf)
-      println(s"Snapshot migration complete! $migrated snapshots were migrated.")
+      val migration = for {
+        snapshotsToMigrate <- countSnapshotsToMigrate(db)
+        _ = log.info(s"Migrating $snapshotsToMigrate snapshots in batches of $RowsPerTransaction.")
+        migrated <- migrateNextBatch(db, migrated = 0, createdFrom = 0L)
+      } yield {
+        log.info(s"Snapshot migration complete! $migrated snapshots were migrated.")
+      }
+      Await.result(migration, Duration.Inf)
     } finally {
       db.close()
     }
   }
 
-  private def migrateNextBatch(db: Database, migrated: Long): Future[Long] = {
-    migrateSnapshotBatch(db).flatMap {
-      case 0 =>
-        println(" done!")
+  private def countSnapshotsToMigrate(db: Database) = {
+    val query = SnapshotTable
+      .filter(_.serId.isEmpty)
+      .length
+      .result
+    db.run(query)
+  }
+
+  private def migrateNextBatch(db: Database, migrated: Long, createdFrom: Long): Future[Long] = {
+    migrateSnapshotBatch(db, createdFrom).flatMap {
+      case (_, None) =>
+        log.info("done!")
         Future.successful(migrated)
-      case batch =>
-        print(".")
-        migrateNextBatch(db, migrated + batch)
+      case (batch, Some(maxHandledCreated)) =>
+        log.info(s"$batch snapshots have been migrated")
+        migrateNextBatch(db, migrated + batch, maxHandledCreated)
     }
   }
 
-  private def migrateSnapshotBatch(db: Database): Future[Int] = {
+  private def migrateSnapshotBatch(db: Database, createdFrom: Long): Future[(Int, Option[Long])] = {
     val batchUpdate = SnapshotTable
-      .filter(_.snapshotData.isEmpty)
+      .filter(_.serId.isEmpty)
+      .filter(_.created > createdFrom)
+      .sortBy(_.created.asc)
       .take(RowsPerTransaction)
       .result
       .flatMap(rows => {
+        val maxHandledCreated: Option[Long] = if (rows.nonEmpty) Some(rows.map(_.created).max) else None
         val updates = rows.map { row =>
           val migration = serializer.deserialize(row).flatMap {
             case (metadata, snapshot) =>
@@ -154,7 +186,7 @@ class V4SnapshotMigration(config: Config, system: ActorSystem) extends SnapshotT
               throw new RuntimeException(s"Migration of snapshot with persistence id ${row.persistenceId} and sequence number ${row.sequenceNumber} failed", error)
           }
         }
-        DBIO.seq(updates: _*).map(_ => updates.size)
+        DBIO.seq(updates: _*).map(_ => (updates.size, maxHandledCreated))
       })
 
     db.run(batchUpdate)

--- a/src/main/scala/akka/persistence/jdbc/migraition/V4Migration.scala
+++ b/src/main/scala/akka/persistence/jdbc/migraition/V4Migration.scala
@@ -2,18 +2,18 @@ package akka.persistence.jdbc.migraition
 
 import akka.actor.ActorSystem
 import akka.event.Logging
-import akka.persistence.jdbc.config.{JournalConfig, JournalTableConfiguration, SnapshotConfig}
-import akka.persistence.jdbc.journal.dao.{ByteArrayJournalSerializer, JournalTables}
-import akka.persistence.jdbc.snapshot.dao.{ByteArraySnapshotSerializer, SnapshotTables}
-import akka.persistence.jdbc.util.{SlickDatabase, SlickDriver}
+import akka.persistence.jdbc.config.{ JournalConfig, JournalTableConfiguration, SnapshotConfig }
+import akka.persistence.jdbc.journal.dao.{ ByteArrayJournalSerializer, JournalTables, LegacyByteArrayJournalSerializer, LegacyJournalTables }
+import akka.persistence.jdbc.snapshot.dao.{ ByteArraySnapshotSerializer, SnapshotTables }
+import akka.persistence.jdbc.util.{ SlickDatabase, SlickDriver }
 import akka.serialization.SerializationExtension
 import com.typesafe.config.Config
 
-import scala.concurrent.{Await, Future}
+import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
-import scala.util.{Failure, Success}
+import scala.util.{ Failure, Success }
 
-class V4JournalMigration(config: Config, system: ActorSystem) extends JournalTables {
+class V4JournalMigration(config: Config, system: ActorSystem) extends LegacyJournalTables {
 
   private val journalConfig = new JournalConfig(config)
   private val log = Logging(system, classOf[V4JournalMigration])
@@ -29,7 +29,7 @@ class V4JournalMigration(config: Config, system: ActorSystem) extends JournalTab
 
   override def journalTableCfg: JournalTableConfiguration = journalConfig.journalTableConfiguration
 
-  private val serializer = new ByteArrayJournalSerializer(SerializationExtension(system), journalConfig.pluginConfig.tagSeparator,
+  private val serializer = new LegacyByteArrayJournalSerializer(SerializationExtension(system), journalConfig.pluginConfig.tagSeparator,
     false)
 
   /**

--- a/src/main/scala/akka/persistence/jdbc/migraition/V4Migration.scala
+++ b/src/main/scala/akka/persistence/jdbc/migraition/V4Migration.scala
@@ -2,18 +2,18 @@ package akka.persistence.jdbc.migraition
 
 import akka.actor.ActorSystem
 import akka.event.Logging
-import akka.persistence.jdbc.config.{ JournalConfig, JournalTableConfiguration, SnapshotConfig }
-import akka.persistence.jdbc.journal.dao.{ ByteArrayJournalSerializer, JournalTables, LegacyByteArrayJournalSerializer, LegacyJournalTables }
-import akka.persistence.jdbc.snapshot.dao.{ ByteArraySnapshotSerializer, SnapshotTables }
-import akka.persistence.jdbc.util.{ SlickDatabase, SlickDriver }
+import akka.persistence.jdbc.config.{JournalConfig, JournalTableConfiguration, SnapshotConfig}
+import akka.persistence.jdbc.journal.dao.{ByteArrayJournalSerializer, JournalTables}
+import akka.persistence.jdbc.snapshot.dao.{ByteArraySnapshotSerializer, SnapshotTables}
+import akka.persistence.jdbc.util.{SlickDatabase, SlickDriver}
 import akka.serialization.SerializationExtension
 import com.typesafe.config.Config
 
-import scala.concurrent.{ Await, Future }
+import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
-import scala.util.{ Failure, Success }
+import scala.util.{Failure, Success}
 
-class V4JournalMigration(config: Config, system: ActorSystem) extends LegacyJournalTables {
+class V4JournalMigration(config: Config, system: ActorSystem) extends JournalTables {
 
   private val journalConfig = new JournalConfig(config)
   private val log = Logging(system, classOf[V4JournalMigration])
@@ -29,7 +29,7 @@ class V4JournalMigration(config: Config, system: ActorSystem) extends LegacyJour
 
   override def journalTableCfg: JournalTableConfiguration = journalConfig.journalTableConfiguration
 
-  private val serializer = new LegacyByteArrayJournalSerializer(SerializationExtension(system), journalConfig.pluginConfig.tagSeparator,
+  private val serializer = new ByteArrayJournalSerializer(SerializationExtension(system), journalConfig.pluginConfig.tagSeparator,
     false)
 
   /**

--- a/src/main/scala/akka/persistence/jdbc/migraition/V4Migration.scala
+++ b/src/main/scala/akka/persistence/jdbc/migraition/V4Migration.scala
@@ -2,16 +2,16 @@ package akka.persistence.jdbc.migraition
 
 import akka.actor.ActorSystem
 import akka.event.Logging
-import akka.persistence.jdbc.config.{JournalConfig, JournalTableConfiguration, SnapshotConfig}
-import akka.persistence.jdbc.journal.dao.{ByteArrayJournalSerializer, JournalTables}
-import akka.persistence.jdbc.snapshot.dao.{ByteArraySnapshotSerializer, SnapshotTables}
-import akka.persistence.jdbc.util.{SlickDatabase, SlickDriver}
+import akka.persistence.jdbc.config.{ JournalConfig, JournalTableConfiguration, SnapshotConfig }
+import akka.persistence.jdbc.journal.dao.{ ByteArrayJournalSerializer, JournalTables, LegacyByteArrayJournalSerializer }
+import akka.persistence.jdbc.snapshot.dao.{ ByteArraySnapshotSerializer, SnapshotTables }
+import akka.persistence.jdbc.util.{ SlickDatabase, SlickDriver }
 import akka.serialization.SerializationExtension
 import com.typesafe.config.Config
 
-import scala.concurrent.{Await, Future}
+import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
-import scala.util.{Failure, Success}
+import scala.util.{ Failure, Success }
 
 class V4JournalMigration(config: Config, system: ActorSystem) extends JournalTables {
 
@@ -29,8 +29,10 @@ class V4JournalMigration(config: Config, system: ActorSystem) extends JournalTab
 
   override def journalTableCfg: JournalTableConfiguration = journalConfig.journalTableConfiguration
 
-  private val serializer = new ByteArrayJournalSerializer(SerializationExtension(system), journalConfig.pluginConfig.tagSeparator,
-    false)
+  private val serializer = new LegacyByteArrayJournalSerializer(
+    SerializationExtension(system),
+    journalConfig.pluginConfig.tagSeparator,
+    writeMessageColumn = false)
 
   /**
    * The number of rows migrated per transaction.
@@ -65,7 +67,7 @@ class V4JournalMigration(config: Config, system: ActorSystem) extends JournalTab
   }
 
   private def countEventsToMigrate(db: Database) = {
-    val query = JournalTable
+    val query = LegacyJournalTable
       .filter(_.serId.isEmpty)
       .length
       .result
@@ -73,7 +75,7 @@ class V4JournalMigration(config: Config, system: ActorSystem) extends JournalTab
   }
 
   private def migrateJournalBatch(db: Database, orderingFrom: Long): Future[(Int, Option[Long])] = {
-    val batchUpdate = JournalTable
+    val batchUpdate = LegacyJournalTable
       .filter(_.serId.isEmpty)
       .filter(_.ordering > orderingFrom)
       .sortBy(_.ordering.asc)
@@ -86,7 +88,7 @@ class V4JournalMigration(config: Config, system: ActorSystem) extends JournalTab
             case (pr, tags, _) =>
               serializer.serialize(pr, tags).map { journalRow =>
                 val statement = for {
-                  theRow <- JournalTable if theRow.persistenceId === row.persistenceId && theRow.sequenceNumber === row.sequenceNumber
+                  theRow <- LegacyJournalTable if theRow.persistenceId === row.persistenceId && theRow.sequenceNumber === row.sequenceNumber
                 } yield (theRow.event, theRow.eventManifest, theRow.serId, theRow.serManifest, theRow.writerUuid)
                 statement.update(journalRow.event, journalRow.eventManifest, journalRow.serId, journalRow.serManifest, journalRow.writerUuid)
               }

--- a/src/main/scala/akka/persistence/jdbc/package.scala
+++ b/src/main/scala/akka/persistence/jdbc/package.scala
@@ -17,7 +17,27 @@
 package akka.persistence
 
 package object jdbc {
+  abstract class AbstractJournalRow {
+    def ordering: Long
+    def deleted: Boolean
+    def persistenceId: String
+    def sequenceNumber: Long
+    def tags: Option[String]
+  }
+
   final case class JournalRow(
+      ordering: Long,
+      deleted: Boolean,
+      persistenceId: String,
+      sequenceNumber: Long,
+      tags: Option[String] = None,
+      event: Array[Byte],
+      eventManifest: Option[String],
+      serId: Int,
+      serManifest: Option[String],
+      writerUuid: String) extends AbstractJournalRow
+
+  final case class LegacyJournalRow(
       ordering: Long,
       deleted: Boolean,
       persistenceId: String,
@@ -29,5 +49,5 @@ package object jdbc {
       eventManifest: Option[String],
       serId: Option[Int],
       serManifest: Option[String],
-      writerUuid: Option[String])
+      writerUuid: Option[String]) extends AbstractJournalRow
 }

--- a/src/main/scala/akka/persistence/jdbc/query/dao/ByteArrayReadJournalDao.scala
+++ b/src/main/scala/akka/persistence/jdbc/query/dao/ByteArrayReadJournalDao.scala
@@ -90,11 +90,7 @@ trait OracleReadJournalDao extends ReadJournalDao {
     }
   }
 
-  implicit val getJournalRow = if (hasMessageColumn) {
-    GetResult(r => JournalRow(r.<<, r.<<, r.<<, r.<<, r.nextBytesOption(), r.<<, r.nextBytesOption(), r.<<, r.<<, r.<<, r.<<))
-  } else {
-    GetResult(r => JournalRow(r.<<, r.<<, r.<<, r.<<, None, r.<<, r.nextBytesOption(), r.<<, r.<<, r.<<, r.<<))
-  }
+  implicit val getJournalRow = GetResult(r => JournalRow(r.<<, r.<<, r.<<, r.<<, None, r.nextBytes(), r.<<, r.<<, r.<<, r.<<))
 
   abstract override def eventsByTag(tag: String, offset: Long, maxOffset: Long, max: Long): Source[Try[(PersistentRepr, Set[String], Long)], NotUsed] = {
     if (isOracleDriver(profile)) {
@@ -191,6 +187,6 @@ class ByteArrayReadJournalDao(
     serialization: Serialization)(implicit ec: ExecutionContext, mat: Materializer) extends BaseByteArrayReadJournalDao with OracleReadJournalDao with H2ReadJournalDao {
 
   val queries = new ReadJournalQueries(profile, readJournalConfig)
-  val serializer = new ByteArrayJournalSerializer(serialization, readJournalConfig.pluginConfig.tagSeparator, readJournalConfig.journalTableConfiguration.writeMessageColumn)
+  val serializer = new ByteArrayJournalSerializer(serialization, readJournalConfig.pluginConfig.tagSeparator)
 
 }

--- a/src/main/scala/akka/persistence/jdbc/snapshot/dao/ByteArraySnapshotSerializer.scala
+++ b/src/main/scala/akka/persistence/jdbc/snapshot/dao/ByteArraySnapshotSerializer.scala
@@ -20,9 +20,9 @@ import akka.persistence.SnapshotMetadata
 import akka.persistence.jdbc.serialization.SnapshotSerializer
 import akka.persistence.jdbc.snapshot.dao.SnapshotTables.SnapshotRow
 import akka.persistence.serialization.Snapshot
-import akka.serialization.{Serialization, SerializerWithStringManifest, Serializers}
+import akka.serialization.{ Serialization, SerializerWithStringManifest, Serializers }
 
-import scala.util.{Failure, Success, Try}
+import scala.util.{ Failure, Success, Try }
 
 class ByteArraySnapshotSerializer(serialization: Serialization, writeSnapshotColumn: Boolean) extends SnapshotSerializer[SnapshotRow] {
 

--- a/src/test/scala/akka/persistence/jdbc/migration/V4MigrationSpec.scala
+++ b/src/test/scala/akka/persistence/jdbc/migration/V4MigrationSpec.scala
@@ -1,13 +1,13 @@
 package akka.persistence.jdbc.migration
 
-import java.io.{File, FileOutputStream}
+import java.io.{ File, FileOutputStream }
 import java.nio.file.Files
 
-import akka.actor.{ActorSystem, Props}
+import akka.actor.{ ActorSystem, Props }
 import akka.persistence.PersistentActor
 import akka.persistence.jdbc.SimpleSpec
 import akka.persistence.jdbc.config.JournalConfig
-import akka.persistence.jdbc.util.{ClasspathResources, DropCreate, SlickDatabase}
+import akka.persistence.jdbc.util.{ ClasspathResources, DropCreate, SlickDatabase }
 import com.typesafe.config.ConfigFactory
 import org.h2.util.IOUtils
 import org.scalatest.BeforeAndAfter

--- a/src/test/scala/akka/persistence/jdbc/snapshot/JdbcSnapshotStoreSpec.scala
+++ b/src/test/scala/akka/persistence/jdbc/snapshot/JdbcSnapshotStoreSpec.scala
@@ -19,9 +19,9 @@ package akka.persistence.jdbc.snapshot
 import akka.persistence.CapabilityFlag
 import akka.persistence.jdbc.config._
 import akka.persistence.jdbc.util.Schema._
-import akka.persistence.jdbc.util.{ClasspathResources, DropCreate, SlickDatabase}
+import akka.persistence.jdbc.util.{ ClasspathResources, DropCreate, SlickDatabase }
 import akka.persistence.snapshot.SnapshotStoreSpec
-import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.config.{ Config, ConfigFactory }
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
 


### PR DESCRIPTION
Here is my very draft of address #199 second point. It looks to me it does not worth an effort or requires to introduce some more complexity. 

It seems abstracting on the Table definition is not possible because of slick complexity with typing/type aliases/etc, so it will be only possible on DAO level, end solution would have 2 DAO's - one for legacy, another one for new journal. Same goes for Read-side DAO. It looks to me it will be a lot of copy-paste as well, as I was not able to abstract over queries. 

While doing this exercise I started to think that the best would be to release 2 versions - one for migration and backward/forward compatibility and another one for those who start from scratch or who already migrated their journals. Migration version could be supported for a while and then dropped at some point.

Let me know your opinion or help me with the direction. I am happy to continue if you agree it is worth it.
