### PR TITLE
Use systemActorOf to allow use with Akka Typed

### DIFF
--- a/src/main/scala/akka/persistence/jdbc/query/scaladsl/JdbcReadJournal.scala
+++ b/src/main/scala/akka/persistence/jdbc/query/scaladsl/JdbcReadJournal.scala
@@ -97,7 +97,7 @@ class JdbcReadJournal(config: Config, configPath: String)(implicit val system: E
   }
 
   // Started lazily to prevent the actor for querying the db if no eventsByTag queries are used
-  private[query] lazy val journalSequenceActor = system.actorOf(
+  private[query] lazy val journalSequenceActor = system.systemActorOf(
     JournalSequenceActor.props(readJournalDao, readJournalConfig.journalSequenceRetrievalConfiguration),
     s"$configPath.akka-persistence-jdbc-journal-sequence-actor")
   private val delaySource =


### PR DESCRIPTION
Switch the JdbcReadJournal actor to be created as a system actor so it can be used with Akka Typed. The same thing had to be done in this [library](https://github.com/dnvriend/akka-persistence-inmemory/pull/54). 

I did a search of the entire code base to make sure `actorOf` isn't used anywhere else. It is used in the tests but I didn't change those since it doesn't impact users.