### PR TITLE
#199 WIP. Fixing DDL generation.

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -16,6 +16,11 @@ akka-persistence-jdbc {
 
   migration {
     v4 {
+      #Number of rows to be migrated in the journal per single transaction in the database
+      journal.rows-per-transaction = 100
+      #Number of rows to be migrated in the snapshot store per single transaction in the database
+      snapshot.rows-per-transaction = 100
+
       # Enables backwards compatibility when migrating to version 4.x, to ensure that any old events or snapshots
       # persisted by akka-persistence-jdbc 3.x can still be read by akka-persistence-jdbc 4.x. This must be enabled
       # if you have data in your database that was produced by akka-persistence-jdbc 3.x, otherwise that data will not

--- a/src/main/scala/akka/persistence/jdbc/journal/dao/ByteArrayJournalSerializer.scala
+++ b/src/main/scala/akka/persistence/jdbc/journal/dao/ByteArrayJournalSerializer.scala
@@ -20,7 +20,7 @@ package journal.dao
 import akka.actor.ActorRef
 import akka.persistence.PersistentRepr
 import akka.persistence.jdbc.serialization.FlowPersistentReprSerializer
-import akka.serialization.{ Serialization, SerializerWithStringManifest, Serializers }
+import akka.serialization.{ Serialization, Serializers }
 
 import scala.collection.immutable._
 import scala.util.{ Failure, Success, Try }

--- a/src/main/scala/akka/persistence/jdbc/journal/dao/JournalTables.scala
+++ b/src/main/scala/akka/persistence/jdbc/journal/dao/JournalTables.scala
@@ -46,13 +46,29 @@ trait JournalTables {
     val deleted: Rep[Boolean] = column[Boolean](journalTableCfg.columnNames.deleted, O.Default(false))
     val tags: Rep[Option[String]] = column[Option[String]](journalTableCfg.columnNames.tags, O.Length(255, varying = true))
     @deprecated("This was used to store the the PersistentRepr serialized as is, but no longer.", "4.0.0")
-    private[dao] val message: Rep[Option[Array[Byte]]] = column[Array[Byte]](journalTableCfg.columnNames.message)
+    private[dao] val message: Rep[Option[Array[Byte]]] = column[Option[Array[Byte]]](journalTableCfg.columnNames.message)
 
-    val event: Rep[Option[Array[Byte]]] = column[Option[Array[Byte]]](journalTableCfg.columnNames.event)
-    val eventManifest: Rep[Option[String]] = column[Option[String]](journalTableCfg.columnNames.eventManifest, O.Length(255, varying = true))
-    val serId: Rep[Option[Int]] = column[Option[Int]](journalTableCfg.columnNames.serId)
-    val serManifest: Rep[Option[String]] = column[Option[String]](journalTableCfg.columnNames.serManifest, O.Length(255, varying = true))
-    val writerUuid: Rep[Option[String]] = column[Option[String]](journalTableCfg.columnNames.writerUuid, O.Length(36, varying = true))
+    val eventManifest: Rep[Option[String]] = if (journalTableCfg.hasMessageColumn)
+      column[Option[String]](journalTableCfg.columnNames.eventManifest, O.Length(255, varying = true))
+    else
+      Rep.Some(column[String](journalTableCfg.columnNames.eventManifest, O.Length(255, varying = true)))
+
+    val event: Rep[Option[Array[Byte]]] =
+      if (journalTableCfg.hasMessageColumn) column[Option[Array[Byte]]](journalTableCfg.columnNames.event)
+      else Rep.Some(column[Array[Byte]](journalTableCfg.columnNames.event))
+
+    val serId: Rep[Option[Int]] =
+      if (journalTableCfg.hasMessageColumn) column[Option[Int]](journalTableCfg.columnNames.serId)
+      else Rep.Some(column[Int](journalTableCfg.columnNames.serId))
+
+    val writerUuid: Rep[Option[String]] =
+      if (journalTableCfg.hasMessageColumn) column[Option[String]](journalTableCfg.columnNames.writerUuid, O.Length(36, varying = true))
+      else Rep.Some(column[String](journalTableCfg.columnNames.writerUuid, O.Length(36, varying = true)))
+
+    val serManifest: Rep[Option[String]] = if (journalTableCfg.hasMessageColumn)
+      column[Option[String]](journalTableCfg.columnNames.serManifest, O.Length(255, varying = true))
+    else
+      Rep.Some(column[String](journalTableCfg.columnNames.serManifest, O.Length(255, varying = true)))
 
     val pk = primaryKey(s"${tableName}_pk", (persistenceId, sequenceNumber))
     val orderingIdx = index(s"${tableName}_ordering_idx", ordering, unique = true)

--- a/src/main/scala/akka/persistence/jdbc/snapshot/dao/SnapshotTables.scala
+++ b/src/main/scala/akka/persistence/jdbc/snapshot/dao/SnapshotTables.scala
@@ -64,8 +64,13 @@ trait SnapshotTables {
     @deprecated("This was used to store the the snapshot serialized wrapped in a Snapshot object, but no longer.", "4.0.0")
     val snapshot: Rep[Option[Array[Byte]]] = column[Option[Array[Byte]]](snapshotTableCfg.columnNames.snapshot)
     val snapshotData: Rep[Option[Array[Byte]]] = column[Option[Array[Byte]]](snapshotTableCfg.columnNames.snapshotData)
-    val serId: Rep[Option[Int]] = column[Option[Int]](snapshotTableCfg.columnNames.serId)
-    val serManifest: Rep[Option[String]] = column[Option[String]](snapshotTableCfg.columnNames.serManifest, O.Length(255, varying = true))
+    val serId: Rep[Option[Int]] =
+      if (snapshotTableCfg.hasSnapshotColumn) column[Option[Int]](snapshotTableCfg.columnNames.serId)
+      else Rep.Some(column[Int](snapshotTableCfg.columnNames.serId))
+    val serManifest: Rep[Option[String]] =
+      if (snapshotTableCfg.hasSnapshotColumn) column[Option[String]](snapshotTableCfg.columnNames.serManifest, O.Length(255, varying = true))
+      else Rep.Some(column[String](snapshotTableCfg.columnNames.serManifest, O.Length(255, varying = true)))
+
     val pk = primaryKey(s"${tableName}_pk", (persistenceId, sequenceNumber))
   }
 

--- a/src/test/resources/schema/oracle/oracle-migration-v4.sql
+++ b/src/test/resources/schema/oracle/oracle-migration-v4.sql
@@ -1,4 +1,3 @@
-ALTER TABLE "journal" MODIFY "message" BLOB DEFAULT NULL;
 ALTER TABLE "journal" ADD (
   "event" BLOB DEFAULT NULL,
   "event_manifest" VARCHAR(255) DEFAULT NULL,
@@ -7,7 +6,6 @@ ALTER TABLE "journal" ADD (
   "writer_uuid" VARCHAR(36) DEFAULT NULL
 );
 
-ALTER TABLE "snapshot" MODIFY "snapshot" BLOB DEFAULT NULL;
 ALTER TABLE "snapshot" ADD (
   "snapshot_data" BLOB DEFAULT NULL,
   "ser_id" INTEGER DEFAULT NULL,

--- a/src/test/scala/akka/persistence/jdbc/migration/V4MigrationSpec.scala
+++ b/src/test/scala/akka/persistence/jdbc/migration/V4MigrationSpec.scala
@@ -52,7 +52,7 @@ class V4MigrationSpec extends SimpleSpec with BeforeAndAfter with ClasspathResou
   }
 
   it should "support loading a V3 events after event migration" in {
-    new V4JournalMigration(backwardsCompatiblilityConfig().getConfig("jdbc-journal"), system).run()
+    new V4JournalMigration(backwardsCompatiblilityConfig(), system).run()
     system = ActorSystem("test", loadConfig(""))
     // JDBC journal is not configured to use old data, so will only read new data, assuming its migrated.
     Await.result(system.actorOf(Props(new TestActor)) ? "load", 10.seconds) shouldBe "abcdef"


### PR DESCRIPTION
#199 
Fixed DDL generation for legacy and non-legacy journal/snapshot table definitions.
Rows per transaction has been made configurable.
event_manifest column has been removed as it's duplicated with ser_manifest in the journal.