### PR TITLE
writeJournalRows runs always in a transaction

### DIFF
--- a/src/main/scala/akka/persistence/jdbc/journal/dao/ByteArrayJournalDao.scala
+++ b/src/main/scala/akka/persistence/jdbc/journal/dao/ByteArrayJournalDao.scala
@@ -85,12 +85,8 @@ trait BaseByteArrayJournalDao extends JournalDaoWithUpdates {
   }
 
   private def writeJournalRows(xs: Seq[JournalRow]): Future[Unit] = {
-    if (slickProfile != H2Profile)
-      // Write atomically without auto-commit
-      db.run(queries.writeJournalRows(xs).transactionally).map(_ => Unit)
-    else
-      // However transactionally causes H2 tests to fail
-      db.run(queries.writeJournalRows(xs)).map(_ => Unit)
+    // Write atomically without auto-commit
+    db.run(queries.writeJournalRows(xs).transactionally).map(_ => Unit)
   }
 
   /**

--- a/src/test/resources/h2-application.conf
+++ b/src/test/resources/h2-application.conf
@@ -32,6 +32,7 @@ akka {
 
 jdbc-journal {
   slick = ${slick}
+  parallelism = 4
 }
 
 # the akka-persistence-snapshot-store in use

--- a/src/test/resources/h2-shared-db-application.conf
+++ b/src/test/resources/h2-shared-db-application.conf
@@ -48,6 +48,7 @@ akka-persistence-jdbc {
 
 jdbc-journal {
   use-shared-db = "slick"
+  parallelism = 4
 }
 
 # the akka-persistence-snapshot-store in use

--- a/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByTagTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByTagTest.scala
@@ -36,7 +36,7 @@ object CurrentEventsByTagTest {
     "jdbc-read-journal.refresh-interval" -> ConfigValueFactory.fromAnyRef(refreshInterval.toString()))
 }
 
-abstract class CurrentEventsByTagTest(config: String, batchSize: Int = 10000) extends QueryTestSpec(config, configOverrides) {
+abstract class CurrentEventsByTagTest(config: String) extends QueryTestSpec(config, configOverrides) {
 
   it should "not find an event by tag for unknown tag" in withActorSystem { implicit system =>
     val journalOps = new ScalaJdbcReadJournalOperations(system)
@@ -190,8 +190,7 @@ abstract class CurrentEventsByTagTest(config: String, batchSize: Int = 10000) ex
       // send a batch of 3 * 200
       val batch1 = sendMessagesWithTag(tag, 200)
       // Try to persist a large batch of events per actor. Some of these may be returned, but not all!
-
-      val batch2 = sendMessagesWithTag(tag, batchSize)
+      val batch2 = sendMessagesWithTag(tag, 10000)
 
       // wait for acknowledgement of the first batch only
       batch1.futureValue
@@ -222,4 +221,4 @@ class OracleScalaCurrentEventsByTagTest extends CurrentEventsByTagTest("oracle-s
 
 class SqlServerScalaCurrentEventsByTagTest extends CurrentEventsByTagTest("sqlserver-shared-db-application.conf") with SqlServerCleaner
 
-class H2ScalaCurrentEventsByTagTest extends CurrentEventsByTagTest("h2-shared-db-application.conf", 5000) with H2Cleaner
+class H2ScalaCurrentEventsByTagTest extends CurrentEventsByTagTest("h2-shared-db-application.conf") with H2Cleaner

--- a/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByTagTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByTagTest.scala
@@ -36,7 +36,7 @@ object CurrentEventsByTagTest {
     "jdbc-read-journal.refresh-interval" -> ConfigValueFactory.fromAnyRef(refreshInterval.toString()))
 }
 
-abstract class CurrentEventsByTagTest(config: String) extends QueryTestSpec(config, configOverrides) {
+abstract class CurrentEventsByTagTest(config: String, batchSize: Int = 10000) extends QueryTestSpec(config, configOverrides) {
 
   it should "not find an event by tag for unknown tag" in withActorSystem { implicit system =>
     val journalOps = new ScalaJdbcReadJournalOperations(system)
@@ -190,7 +190,8 @@ abstract class CurrentEventsByTagTest(config: String) extends QueryTestSpec(conf
       // send a batch of 3 * 200
       val batch1 = sendMessagesWithTag(tag, 200)
       // Try to persist a large batch of events per actor. Some of these may be returned, but not all!
-      val batch2 = sendMessagesWithTag(tag, 10000)
+
+      val batch2 = sendMessagesWithTag(tag, batchSize)
 
       // wait for acknowledgement of the first batch only
       batch1.futureValue
@@ -221,4 +222,4 @@ class OracleScalaCurrentEventsByTagTest extends CurrentEventsByTagTest("oracle-s
 
 class SqlServerScalaCurrentEventsByTagTest extends CurrentEventsByTagTest("sqlserver-shared-db-application.conf") with SqlServerCleaner
 
-class H2ScalaCurrentEventsByTagTest extends CurrentEventsByTagTest("h2-shared-db-application.conf") with H2Cleaner
+class H2ScalaCurrentEventsByTagTest extends CurrentEventsByTagTest("h2-shared-db-application.conf", 5000) with H2Cleaner


### PR DESCRIPTION
This PR removes the if/else for H2 DB in `writeJournalRows`