### PR TITLE
Ensure only one row is returned in appropriate snapshot queries

### DIFF
--- a/src/main/scala/akka/persistence/jdbc/snapshot/dao/SnapshotQueries.scala
+++ b/src/main/scala/akka/persistence/jdbc/snapshot/dao/SnapshotQueries.scala
@@ -41,14 +41,14 @@ class SnapshotQueries(val profile: JdbcProfile, override val snapshotTableCfg: S
   val selectByPersistenceIdAndSeqNr = Compiled(_selectByPersistenceIdAndSeqNr _)
 
   private def _selectByPersistenceIdAndMaxTimestamp(persistenceId: Rep[String], maxTimestamp: Rep[Long]) =
-    _selectAll(persistenceId).filter(_.created <= maxTimestamp)
+    _selectAll(persistenceId).filter(_.created <= maxTimestamp).take(1)
   val selectByPersistenceIdAndMaxTimestamp = Compiled(_selectByPersistenceIdAndMaxTimestamp _)
 
   private def _selectByPersistenceIdAndMaxSequenceNr(persistenceId: Rep[String], maxSequenceNr: Rep[Long]) =
-    _selectAll(persistenceId).filter(_.sequenceNumber <= maxSequenceNr)
+    _selectAll(persistenceId).filter(_.sequenceNumber <= maxSequenceNr).take(1)
   val selectByPersistenceIdAndMaxSequenceNr = Compiled(_selectByPersistenceIdAndMaxSequenceNr _)
 
   private def _selectByPersistenceIdAndMaxSequenceNrAndMaxTimestamp(persistenceId: Rep[String], maxSequenceNr: Rep[Long], maxTimestamp: Rep[Long]) =
-    _selectByPersistenceIdAndMaxSequenceNr(persistenceId, maxSequenceNr).filter(_.created <= maxTimestamp)
+    _selectByPersistenceIdAndMaxSequenceNr(persistenceId, maxSequenceNr).filter(_.created <= maxTimestamp).take(1)
   val selectByPersistenceIdAndMaxSequenceNrAndMaxTimestamp = Compiled(_selectByPersistenceIdAndMaxSequenceNrAndMaxTimestamp _)
 }


### PR DESCRIPTION
We recently found that recovering an actor with large sized snapshots failed due to a missing limit on the query. The query as is stands returns every snapshot meeting the criteria which for us was several 10s of GBs of data.

There was an existing limit on  `_selectByPersistenceIdAndMaxSeqNr`, but none on the other 3 similar queries where a max sequence number or timestamp are specified:

- _selectByPersistenceIdAndMaxTimestamp
- _selectByPersistenceIdAndMaxSequenceNr
- _selectByPersistenceIdAndMaxSequenceNrAndMaxTimestamp