### PR TITLE
Fix for oracle memory issues with large snapshots.

### DIFF
--- a/src/main/scala/akka/persistence/jdbc/util/InputStreamOps.scala
+++ b/src/main/scala/akka/persistence/jdbc/util/InputStreamOps.scala
@@ -16,10 +16,26 @@
 
 package akka.persistence.jdbc.util
 
-import java.io.InputStream
+import java.io.{ByteArrayOutputStream, InputStream}
+
+import scala.concurrent.blocking
 
 object InputStreamOps {
-  implicit class InputStreamImplicits(val that: InputStream) extends AnyVal {
-    def toArray: Array[Byte] = Stream.continually(that.read).takeWhile(_ != -1).map(_.toByte).toArray
+  implicit class InputStreamImplicits(val is: InputStream) extends AnyVal {
+    def toArray: Array[Byte] = blocking {
+      /* based on https://stackoverflow.com/a/17861016/865265
+       * Thanks to
+       * - https://stackoverflow.com/users/1435969/ivan-gammel
+       * - https://stackoverflow.com/users/2619133/oliverkn
+       */
+      val bos: ByteArrayOutputStream = new ByteArrayOutputStream
+      val buffer: Array[Byte] = new Array[Byte](0xFFFF)
+      var len: Int = is.read(buffer)
+      while (len != -1) {
+        bos.write(buffer, 0, len)
+        len = is.read(buffer)
+      }
+      bos.toByteArray
+    }
   }
 }


### PR DESCRIPTION
Use a more imperative algorithm for converting an inputstream to a bytearray, which should save a lot of memory

It seems that the old version of the code, allocated a stream Cons object (32 bits) and an interger (another 32 bits) for every byte of data read from a message or snapshot. If snapshots would be very large the memory usage would be more that 8 times the original size of the snapshot (in the best case). This algorithm should be more efficient.

Note that the code is based on an example on stackoverflow, as java 8 does not yet have a simple utility to convert an inputstream to a bytearray.

Note: this code (just like the previous version) is blocking