### PR TITLE
travis settings and h2 transactionally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ services:
   - postgresql
   - docker
 before_install:
-  - docker pull alexeiled/docker-oracle-xe-11g
+  - docker pull wnameless/oracle-xe-11g
   - docker pull topaztechnology/mssql-server-linux
-  - docker run --name oracle -d -p 127.0.0.1:1521:1521 -e ORACLE_ALLOW_REMOTE=true alexeiled/docker-oracle-xe-11g
+  - docker run --name oracle -d -p 127.0.0.1:1521:1521 -e ORACLE_ALLOW_REMOTE=true wnameless/oracle-xe-11g
   - docker run --name sqlserver -d -p 127.0.0.1:1433:1433 -e DBCA_TOTAL_MEMORY=1024 -e ACCEPT_EULA=Y -e SQL_USER=docker -e SQL_PASSWORD=docker -e SQL_DB=docker topaztechnology/mssql-server-linux
   - docker inspect oracle
   - docker inspect sqlserver

--- a/build.sh
+++ b/build.sh
@@ -22,4 +22,4 @@ wait 3306 MySQL
 wait 1521 Oracle
 wait 1433 SqlSever
 
-sbt test
+sbt ++$TRAVIS_SCALA_VERSION test

--- a/project/ProjectAutoPlugin.scala
+++ b/project/ProjectAutoPlugin.scala
@@ -83,7 +83,7 @@ object ProjectAutoPlugin extends AutoPlugin {
    libraryDependencies += "com.typesafe.slick" %% "slick" % SlickVersion,
    libraryDependencies += "com.typesafe.slick" %% "slick-hikaricp" % SlickVersion,
    libraryDependencies += "org.postgresql" % "postgresql" % "42.2.5" % Test,
-   libraryDependencies += "com.h2database" % "h2" % "1.4.197" % Test,
+   libraryDependencies += "com.h2database" % "h2" % "1.4.196" % Test,
    libraryDependencies += "mysql" % "mysql-connector-java" % "8.0.12" % Test,
    libraryDependencies += "com.microsoft.sqlserver" % "mssql-jdbc" % "7.0.0.jre8" % Test,
    libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3" % Test,

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -18,7 +18,7 @@ mysql:
     - "3306:3306" # credentials (root:root)
 
 oracle:
-  image: alexeiled/docker-oracle-xe-11g 
+  image: wnameless/oracle-xe-11g
   container_name: oracle-test
   environment:
     - "TZ=Europe/Amsterdam"

--- a/src/main/scala/akka/persistence/jdbc/journal/dao/ByteArrayJournalDao.scala
+++ b/src/main/scala/akka/persistence/jdbc/journal/dao/ByteArrayJournalDao.scala
@@ -85,12 +85,8 @@ trait BaseByteArrayJournalDao extends JournalDaoWithUpdates {
   }
 
   private def writeJournalRows(xs: Seq[JournalRow]): Future[Unit] = {
-    if (slickProfile != H2Profile)
-      // Write atomically without auto-commit
-      db.run(queries.writeJournalRows(xs).transactionally).map(_ => Unit)
-    else
-      // However transactionally causes H2 tests to fail
-      db.run(queries.writeJournalRows(xs)).map(_ => Unit)
+    // Write atomically without auto-commit
+    db.run(queries.writeJournalRows(xs).transactionally).map(_ => Unit)
   }
 
   /**


### PR DESCRIPTION
This PR includes the first commit of #207 so that the writing of journal rows always runs in a transaction regardless of which database is used.

~~It turn out that H2 needs a bit more memory, however from some of my tests, it seemed that the memory settings we try to pass in the .sbtopts file are overridden by travis. To work around this I pass the memory parameters to SBT explicitly~~

It seems that the issues we are having with h2 only occur in h2 version 1.4.197 and not in the previous version. So I downloaded h2 to 1.4.196. (many issues seem to have been reported and fixed on 197, but no release has been made yet for 9 months).

In addition I discovered another bug in our build, namely that the scala 2.11 build was actually a scala 2.12 build... This has been fixed too.

Edit: 
Somehow our oracle image got deleted from the docker hub again, however the one that we used half a year ago is back again. So I switched back to that oracle image

