### PR TITLE
Fix snapshot lookup queries and improve naming for consistency and clarity

### DIFF
--- a/src/main/scala/akka/persistence/jdbc/snapshot/JdbcSnapshotStore.scala
+++ b/src/main/scala/akka/persistence/jdbc/snapshot/JdbcSnapshotStore.scala
@@ -71,7 +71,7 @@ class JdbcSnapshotStore(config: Config) extends SnapshotStore {
     criteria: SnapshotSelectionCriteria): Future[Option[SelectedSnapshot]] = {
     val result = criteria match {
       case SnapshotSelectionCriteria(Long.MaxValue, Long.MaxValue, _, _) =>
-        snapshotDao.snapshotForMaxSequenceNr(persistenceId)
+        snapshotDao.latestSnapshot(persistenceId)
       case SnapshotSelectionCriteria(Long.MaxValue, maxTimestamp, _, _) =>
         snapshotDao.snapshotForMaxTimestamp(persistenceId, maxTimestamp)
       case SnapshotSelectionCriteria(maxSequenceNr, Long.MaxValue, _, _) =>

--- a/src/main/scala/akka/persistence/jdbc/snapshot/dao/ByteArraySnapshotDao.scala
+++ b/src/main/scala/akka/persistence/jdbc/snapshot/dao/ByteArraySnapshotDao.scala
@@ -70,14 +70,14 @@ class ByteArraySnapshotDao(db: JdbcBackend#Database, profile: JdbcProfile, snaps
   } yield ()
 
   override def deleteUpToMaxSequenceNr(persistenceId: String, maxSequenceNr: Long): Future[Unit] = for {
-    _ <- db.run(queries.selectByPersistenceIdAndMaxSequenceNr(persistenceId, maxSequenceNr).delete)
+    _ <- db.run(queries.selectOneByPersistenceIdAndMaxSequenceNr(persistenceId, maxSequenceNr).delete)
   } yield ()
 
   override def deleteUpToMaxTimestamp(persistenceId: String, maxTimestamp: Long): Future[Unit] = for {
-    _ <- db.run(queries.selectByPersistenceIdAndMaxTimestamp(persistenceId, maxTimestamp).delete)
+    _ <- db.run(queries.selectOneByPersistenceIdAndMaxTimestamp(persistenceId, maxTimestamp).delete)
   } yield ()
 
   override def deleteUpToMaxSequenceNrAndMaxTimestamp(persistenceId: String, maxSequenceNr: Long, maxTimestamp: Long): Future[Unit] = for {
-    _ <- db.run(queries.selectByPersistenceIdAndMaxSequenceNrAndMaxTimestamp(persistenceId, maxSequenceNr, maxTimestamp).delete)
+    _ <- db.run(queries.selectOneByPersistenceIdAndMaxSequenceNrAndMaxTimestamp(persistenceId, maxSequenceNr, maxTimestamp).delete)
   } yield ()
 }

--- a/src/main/scala/akka/persistence/jdbc/snapshot/dao/ByteArraySnapshotDao.scala
+++ b/src/main/scala/akka/persistence/jdbc/snapshot/dao/ByteArraySnapshotDao.scala
@@ -40,20 +40,20 @@ class ByteArraySnapshotDao(db: JdbcBackend#Database, profile: JdbcProfile, snaps
       case Failure(cause)        => throw cause
     }
 
-  override def snapshotForMaxSequenceNr(persistenceId: String): Future[Option[(SnapshotMetadata, Any)]] = for {
-    rows <- db.run(queries.selectByPersistenceIdAndMaxSeqNr(persistenceId).result)
+  override def latestSnapshot(persistenceId: String): Future[Option[(SnapshotMetadata, Any)]] = for {
+    rows <- db.run(queries.selectLatestByPersistenceId(persistenceId).result)
   } yield rows.headOption map toSnapshotData
 
   override def snapshotForMaxTimestamp(persistenceId: String, maxTimestamp: Long): Future[Option[(SnapshotMetadata, Any)]] = for {
-    rows <- db.run(queries.selectByPersistenceIdAndMaxTimestamp(persistenceId, maxTimestamp).result)
+    rows <- db.run(queries.selectOneByPersistenceIdAndMaxTimestamp(persistenceId, maxTimestamp).result)
   } yield rows.headOption map toSnapshotData
 
   override def snapshotForMaxSequenceNr(persistenceId: String, maxSequenceNr: Long): Future[Option[(SnapshotMetadata, Any)]] = for {
-    rows <- db.run(queries.selectByPersistenceIdAndMaxSequenceNr(persistenceId, maxSequenceNr).result)
+    rows <- db.run(queries.selectOneByPersistenceIdAndMaxSequenceNr(persistenceId, maxSequenceNr).result)
   } yield rows.headOption map toSnapshotData
 
   override def snapshotForMaxSequenceNrAndMaxTimestamp(persistenceId: String, maxSequenceNr: Long, maxTimestamp: Long): Future[Option[(SnapshotMetadata, Any)]] = for {
-    rows <- db.run(queries.selectByPersistenceIdAndMaxSequenceNrAndMaxTimestamp(persistenceId, maxSequenceNr, maxTimestamp).result)
+    rows <- db.run(queries.selectOneByPersistenceIdAndMaxSequenceNrAndMaxTimestamp(persistenceId, maxSequenceNr, maxTimestamp).result)
   } yield rows.headOption map toSnapshotData
 
   override def save(snapshotMetadata: SnapshotMetadata, snapshot: Any): Future[Unit] = {
@@ -62,7 +62,7 @@ class ByteArraySnapshotDao(db: JdbcBackend#Database, profile: JdbcProfile, snaps
   }
 
   override def delete(persistenceId: String, sequenceNr: Long): Future[Unit] = for {
-    _ <- db.run(queries.selectByPersistenceIdAndSeqNr(persistenceId, sequenceNr).delete)
+    _ <- db.run(queries.selectByPersistenceIdAndSequenceNr(persistenceId, sequenceNr).delete)
   } yield ()
 
   override def deleteAllSnapshots(persistenceId: String): Future[Unit] = for {
@@ -70,14 +70,14 @@ class ByteArraySnapshotDao(db: JdbcBackend#Database, profile: JdbcProfile, snaps
   } yield ()
 
   override def deleteUpToMaxSequenceNr(persistenceId: String, maxSequenceNr: Long): Future[Unit] = for {
-    _ <- db.run(queries.selectOneByPersistenceIdAndMaxSequenceNr(persistenceId, maxSequenceNr).delete)
+    _ <- db.run(queries.selectByPersistenceIdUpToMaxSequenceNr(persistenceId, maxSequenceNr).delete)
   } yield ()
 
   override def deleteUpToMaxTimestamp(persistenceId: String, maxTimestamp: Long): Future[Unit] = for {
-    _ <- db.run(queries.selectOneByPersistenceIdAndMaxTimestamp(persistenceId, maxTimestamp).delete)
+    _ <- db.run(queries.selectByPersistenceIdUpToMaxTimestamp(persistenceId, maxTimestamp).delete)
   } yield ()
 
   override def deleteUpToMaxSequenceNrAndMaxTimestamp(persistenceId: String, maxSequenceNr: Long, maxTimestamp: Long): Future[Unit] = for {
-    _ <- db.run(queries.selectOneByPersistenceIdAndMaxSequenceNrAndMaxTimestamp(persistenceId, maxSequenceNr, maxTimestamp).delete)
+    _ <- db.run(queries.selectByPersistenceIdUpToMaxSequenceNrAndMaxTimestamp(persistenceId, maxSequenceNr, maxTimestamp).delete)
   } yield ()
 }

--- a/src/main/scala/akka/persistence/jdbc/snapshot/dao/SnapshotDao.scala
+++ b/src/main/scala/akka/persistence/jdbc/snapshot/dao/SnapshotDao.scala
@@ -29,7 +29,7 @@ trait SnapshotDao {
 
   def deleteUpToMaxSequenceNrAndMaxTimestamp(persistenceId: String, maxSequenceNr: Long, maxTimestamp: Long): Future[Unit]
 
-  def snapshotForMaxSequenceNr(persistenceId: String): Future[Option[(SnapshotMetadata, Any)]]
+  def latestSnapshot(persistenceId: String): Future[Option[(SnapshotMetadata, Any)]]
 
   def snapshotForMaxTimestamp(persistenceId: String, timestamp: Long): Future[Option[(SnapshotMetadata, Any)]]
 

--- a/src/main/scala/akka/persistence/jdbc/snapshot/dao/SnapshotQueries.scala
+++ b/src/main/scala/akka/persistence/jdbc/snapshot/dao/SnapshotQueries.scala
@@ -32,25 +32,25 @@ class SnapshotQueries(val profile: JdbcProfile, override val snapshotTableCfg: S
     SnapshotTable.filter(_.persistenceId === persistenceId).sortBy(_.sequenceNumber.desc)
   val selectAll = Compiled(_selectAll _)
 
-  private def _selectByPersistenceIdAndMaxSeqNr(persistenceId: Rep[String]) =
+  private def _selectLatestByPersistenceId(persistenceId: Rep[String]) =
     _selectAll(persistenceId).take(1)
-  val selectByPersistenceIdAndMaxSeqNr = Compiled(_selectByPersistenceIdAndMaxSeqNr _)
+  val selectLatestByPersistenceId = Compiled(_selectLatestByPersistenceId _)
 
-  private def _selectByPersistenceIdAndSeqNr(persistenceId: Rep[String], sequenceNr: Rep[Long]) =
+  private def _selectByPersistenceIdAndSequenceNr(persistenceId: Rep[String], sequenceNr: Rep[Long]) =
     _selectAll(persistenceId).filter(_.sequenceNumber === sequenceNr)
-  val selectByPersistenceIdAndSeqNr = Compiled(_selectByPersistenceIdAndSeqNr _)
+  val selectByPersistenceIdAndSequenceNr = Compiled(_selectByPersistenceIdAndSequenceNr _)
 
-  private def _selectByPersistenceIdAndMaxTimestamp(persistenceId: Rep[String], maxTimestamp: Rep[Long]) =
+  private def _selectByPersistenceIdUpToMaxTimestamp(persistenceId: Rep[String], maxTimestamp: Rep[Long]) =
     _selectAll(persistenceId).filter(_.created <= maxTimestamp)
-  val selectByPersistenceIdAndMaxTimestamp = Compiled(_selectByPersistenceIdAndMaxTimestamp _)
+  val selectByPersistenceIdUpToMaxTimestamp = Compiled(_selectByPersistenceIdUpToMaxTimestamp _)
 
-  private def _selectByPersistenceIdAndMaxSequenceNr(persistenceId: Rep[String], maxSequenceNr: Rep[Long]) =
+  private def _selectByPersistenceIdUpToMaxSequenceNr(persistenceId: Rep[String], maxSequenceNr: Rep[Long]) =
     _selectAll(persistenceId).filter(_.sequenceNumber <= maxSequenceNr)
-  val selectByPersistenceIdAndMaxSequenceNr = Compiled(_selectByPersistenceIdAndMaxSequenceNr _)
+  val selectByPersistenceIdUpToMaxSequenceNr = Compiled(_selectByPersistenceIdUpToMaxSequenceNr _)
 
-  private def _selectByPersistenceIdAndMaxSequenceNrAndMaxTimestamp(persistenceId: Rep[String], maxSequenceNr: Rep[Long], maxTimestamp: Rep[Long]) =
-    _selectByPersistenceIdAndMaxSequenceNr(persistenceId, maxSequenceNr).filter(_.created <= maxTimestamp)
-  val selectByPersistenceIdAndMaxSequenceNrAndMaxTimestamp = Compiled(_selectByPersistenceIdAndMaxSequenceNrAndMaxTimestamp _)
+  private def _selectByPersistenceIdUpToMaxSequenceNrAndMaxTimestamp(persistenceId: Rep[String], maxSequenceNr: Rep[Long], maxTimestamp: Rep[Long]) =
+    _selectByPersistenceIdUpToMaxSequenceNr(persistenceId, maxSequenceNr).filter(_.created <= maxTimestamp)
+  val selectByPersistenceIdUpToMaxSequenceNrAndMaxTimestamp = Compiled(_selectByPersistenceIdUpToMaxSequenceNrAndMaxTimestamp _)
 
   private def _selectOneByPersistenceIdAndMaxTimestamp(persistenceId: Rep[String], maxTimestamp: Rep[Long]) =
     _selectAll(persistenceId).filter(_.created <= maxTimestamp).take(1)

--- a/src/main/scala/akka/persistence/jdbc/snapshot/dao/SnapshotQueries.scala
+++ b/src/main/scala/akka/persistence/jdbc/snapshot/dao/SnapshotQueries.scala
@@ -61,6 +61,6 @@ class SnapshotQueries(val profile: JdbcProfile, override val snapshotTableCfg: S
   val selectOneByPersistenceIdAndMaxSequenceNr = Compiled(_selectOneByPersistenceIdAndMaxSequenceNr _)
 
   private def _selectOneByPersistenceIdAndMaxSequenceNrAndMaxTimestamp(persistenceId: Rep[String], maxSequenceNr: Rep[Long], maxTimestamp: Rep[Long]) =
-    _selectOneByPersistenceIdAndMaxSequenceNr(persistenceId, maxSequenceNr).filter(_.created <= maxTimestamp).take(1)
+    _selectByPersistenceIdUpToMaxSequenceNr(persistenceId, maxSequenceNr).filter(_.created <= maxTimestamp).take(1)
   val selectOneByPersistenceIdAndMaxSequenceNrAndMaxTimestamp = Compiled(_selectOneByPersistenceIdAndMaxSequenceNrAndMaxTimestamp _)
 }

--- a/src/main/scala/akka/persistence/jdbc/snapshot/dao/SnapshotQueries.scala
+++ b/src/main/scala/akka/persistence/jdbc/snapshot/dao/SnapshotQueries.scala
@@ -51,4 +51,16 @@ class SnapshotQueries(val profile: JdbcProfile, override val snapshotTableCfg: S
   private def _selectByPersistenceIdAndMaxSequenceNrAndMaxTimestamp(persistenceId: Rep[String], maxSequenceNr: Rep[Long], maxTimestamp: Rep[Long]) =
     _selectByPersistenceIdAndMaxSequenceNr(persistenceId, maxSequenceNr).filter(_.created <= maxTimestamp)
   val selectByPersistenceIdAndMaxSequenceNrAndMaxTimestamp = Compiled(_selectByPersistenceIdAndMaxSequenceNrAndMaxTimestamp _)
+
+  private def _selectOneByPersistenceIdAndMaxTimestamp(persistenceId: Rep[String], maxTimestamp: Rep[Long]) =
+    _selectAll(persistenceId).filter(_.created <= maxTimestamp).take(1)
+  val selectOneByPersistenceIdAndMaxTimestamp = Compiled(_selectOneByPersistenceIdAndMaxTimestamp _)
+
+  private def _selectOneByPersistenceIdAndMaxSequenceNr(persistenceId: Rep[String], maxSequenceNr: Rep[Long]) =
+    _selectAll(persistenceId).filter(_.sequenceNumber <= maxSequenceNr).take(1)
+  val selectOneByPersistenceIdAndMaxSequenceNr = Compiled(_selectOneByPersistenceIdAndMaxSequenceNr _)
+
+  private def _selectOneByPersistenceIdAndMaxSequenceNrAndMaxTimestamp(persistenceId: Rep[String], maxSequenceNr: Rep[Long], maxTimestamp: Rep[Long]) =
+    _selectOneByPersistenceIdAndMaxSequenceNr(persistenceId, maxSequenceNr).filter(_.created <= maxTimestamp).take(1)
+  val selectOneByPersistenceIdAndMaxSequenceNrAndMaxTimestamp = Compiled(_selectOneByPersistenceIdAndMaxSequenceNrAndMaxTimestamp _)
 }


### PR DESCRIPTION
We recently found that recovering an actor with large sized snapshots failed due to a missing limit on the query. The query as is stands returns every snapshot meeting the criteria which for us was several 10s of GBs of data.

There was an existing limit on _selectByPersistenceIdAndMaxSeqNr, but none on the other 3 similar queries where a max sequence number or timestamp are specified:

_selectByPersistenceIdAndMaxTimestamp
_selectByPersistenceIdAndMaxSequenceNr
_selectByPersistenceIdAndMaxSequenceNrAndMaxTimestamp

Since Ruud highlighted that the altered queries were also being used for deletions I've added selectOneBy versions of the existing queries to be used only by the snapshot lookups.

I've also renamed most of the query functions to have a consistence convention and make it clearer what their job is