### PR TITLE
Include openjdk11 in the travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ scala:
   - 2.12.8
 jdk:
   - oraclejdk8
+  - openjdk11
 before_script:
   - psql -c 'create database docker;' -U postgres
 addons:


### PR DESCRIPTION
It seems that the tests succeed. Which I did not really expect since https://github.com/slick/slick/pull/1959 is still open.

Lets keep on running jdk 11 tests on travis, so we ensure that both java versions work fine