### PR TITLE
Enable mima to check binary compatibility

### DIFF
--- a/project/ProjectAutoPlugin.scala
+++ b/project/ProjectAutoPlugin.scala
@@ -2,6 +2,7 @@ import com.typesafe.sbt.SbtScalariform
 import com.typesafe.sbt.SbtScalariform.ScalariformKeys
 import com.typesafe.tools.mima.plugin.MimaPlugin.mimaDefaultSettings
 import com.typesafe.tools.mima.core.IncompatibleResultTypeProblem
+import com.typesafe.tools.mima.core.ProblemFilters
 import com.typesafe.tools.mima.plugin.MimaKeys.{mimaBinaryIssueFilters, mimaPreviousArtifacts}
 import de.heikoseeberger.sbtheader.License.ALv2
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.headerLicense

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,7 +15,7 @@
  */
 
 // to deploy to bintray
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.3")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.5")
 
 // to format scala source code
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
@@ -26,3 +26,5 @@ addSbtPlugin("de.heikoseeberger" % "sbt-header" % "4.1.0")
 // enable release process
 // https://github.com/sbt/sbt-release
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.7")
+
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.3.0")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version := "3.6.0-SNAPSHOT"
+version := "3.5.1-SNAPSHOT"


### PR DESCRIPTION
If I understood correctly the release we want to make this will will be version 3.5.1.

I have added and enabled MiMa to check that this release is compatible with the 3.5.0 release.

There is one incompatibility (for scala 2.11 only), which occurs because the type of a lambda changed. As this lambda is not accessible when compiling, this should not be a problem.