### PR TITLE
Only fetch `batch` number of rows at a time from the db

### DIFF
--- a/src/main/scala/akka/persistence/jdbc/query/scaladsl/JdbcReadJournal.scala
+++ b/src/main/scala/akka/persistence/jdbc/query/scaladsl/JdbcReadJournal.scala
@@ -142,8 +142,7 @@ class JdbcReadJournal(config: Config, configPath: String)(implicit val system: E
         case _ =>
           delaySource
             .flatMapConcat { _ =>
-              currentJournalEventsByPersistenceId(persistenceId, from, toSequenceNr)
-                .take(readJournalConfig.maxBufferSize)
+              currentJournalEventsByPersistenceId(persistenceId, from, from + (readJournalConfig.maxBufferSize - 1))
             }
             .mapConcat(adaptEvents)
             .map(repr => EventEnvelope(Sequence(repr.sequenceNr), repr.persistenceId, repr.sequenceNr, repr.payload))


### PR DESCRIPTION
Rather than fetching potentially all the data for a given persistenceId and then only using the first `maxBufferSize` rows, we should only fetch `maxBufferSize` rows in the first place.