### PR TITLE
Bump akka version to 2.6.0-RC1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ scala:
   - 2.12.8
   - 2.13.0
 jdk:
-  - oraclejdk8
+  - openjdk8
   - openjdk11
 before_script:
   - psql -c 'create database docker;' -U postgres

--- a/README.md
+++ b/README.md
@@ -165,13 +165,13 @@ The plugin supports the following queries:
 
 ```scala
 import akka.actor.ActorSystem
-import akka.stream.{Materializer, ActorMaterializer}
+import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import akka.persistence.query.PersistenceQuery
 import akka.persistence.jdbc.query.scaladsl.JdbcReadJournal
 
 implicit val system: ActorSystem = ActorSystem()
-implicit val mat: Materializer = ActorMaterializer()(system)
+implicit val mat: Materializer = Materializer.matFromSystem(system)
 val readJournal: JdbcReadJournal = PersistenceQuery(system).readJournalFor[JdbcReadJournal](JdbcReadJournal.Identifier)
 
 val willNotCompleteTheStream: Source[String, NotUsed] = readJournal.allPersistenceIds()
@@ -195,13 +195,13 @@ a specific PersistentActor identified by persistenceId.
 
 ```scala
 import akka.actor.ActorSystem
-import akka.stream.{Materializer, ActorMaterializer}
+import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import akka.persistence.query.{ PersistenceQuery, EventEnvelope }
 import akka.persistence.jdbc.query.scaladsl.JdbcReadJournal
 
 implicit val system: ActorSystem = ActorSystem()
-implicit val mat: Materializer = ActorMaterializer()(system)
+implicit val mat: Materializer = Materializer.matFromSystem(system)
 val readJournal: JdbcReadJournal = PersistenceQuery(system).readJournalFor[JdbcReadJournal](JdbcReadJournal.Identifier)
 
 val willNotCompleteTheStream: Source[EventEnvelope, NotUsed] = readJournal.eventsByPersistenceId("some-persistence-id", 0L, Long.MaxValue)
@@ -221,13 +221,13 @@ The stream is completed with failure if there is a failure in executing the quer
 
 ```scala
 import akka.actor.ActorSystem
-import akka.stream.{Materializer, ActorMaterializer}
+import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import akka.persistence.query.{ PersistenceQuery, EventEnvelope }
 import akka.persistence.jdbc.query.scaladsl.JdbcReadJournal
 
 implicit val system: ActorSystem = ActorSystem()
-implicit val mat: Materializer = ActorMaterializer()(system)
+implicit val mat: Materializer = Materializer.matFromSystem(system)
 val readJournal: JdbcReadJournal = PersistenceQuery(system).readJournalFor[JdbcReadJournal](JdbcReadJournal.Identifier)
 
 val willNotCompleteTheStream: Source[EventEnvelope, NotUsed] = readJournal.eventsByTag("apple", 0L)

--- a/project/ProjectAutoPlugin.scala
+++ b/project/ProjectAutoPlugin.scala
@@ -14,7 +14,7 @@ import scalariform.formatter.preferences.FormattingPreferences
 
 object ProjectAutoPlugin extends AutoPlugin {
   final val ScalaVersion = "2.13.0"
-  final val AkkaVersion = "2.5.25"
+  final val AkkaVersion = "2.6.0-RC1"
   final val SlickVersion = "3.3.2"
   final val ScalaTestVersion = "3.0.8"
 

--- a/src/main/scala/akka/persistence/jdbc/journal/JdbcAsyncWriteJournal.scala
+++ b/src/main/scala/akka/persistence/jdbc/journal/JdbcAsyncWriteJournal.scala
@@ -27,7 +27,7 @@ import akka.persistence.jdbc.util.{ SlickDatabase, SlickExtension }
 import akka.persistence.journal.AsyncWriteJournal
 import akka.persistence.{ AtomicWrite, PersistentRepr }
 import akka.serialization.{ Serialization, SerializationExtension }
-import akka.stream.{ ActorMaterializer, Materializer }
+import akka.stream.Materializer
 import com.typesafe.config.Config
 import slick.jdbc.JdbcProfile
 import slick.jdbc.JdbcBackend._
@@ -52,7 +52,7 @@ object JdbcAsyncWriteJournal {
 class JdbcAsyncWriteJournal(config: Config) extends AsyncWriteJournal {
   implicit val ec: ExecutionContext = context.dispatcher
   implicit val system: ActorSystem = context.system
-  implicit val mat: Materializer = ActorMaterializer()
+  implicit val mat: Materializer = Materializer.matFromSystem(system)
   val journalConfig = new JournalConfig(config)
 
   val slickDb: SlickDatabase = SlickExtension(system).database(config)

--- a/src/main/scala/akka/persistence/jdbc/query/scaladsl/JdbcReadJournal.scala
+++ b/src/main/scala/akka/persistence/jdbc/query/scaladsl/JdbcReadJournal.scala
@@ -28,7 +28,7 @@ import akka.persistence.query.{ EventEnvelope, Offset, Sequence }
 import akka.persistence.{ Persistence, PersistentRepr }
 import akka.serialization.{ Serialization, SerializationExtension }
 import akka.stream.scaladsl.{ Sink, Source }
-import akka.stream.{ ActorMaterializer, Materializer }
+import akka.stream.Materializer
 import akka.util.Timeout
 import com.typesafe.config.Config
 import slick.jdbc.JdbcBackend._
@@ -66,7 +66,7 @@ class JdbcReadJournal(config: Config, configPath: String)(implicit val system: E
   with EventsByTagQuery {
 
   implicit val ec: ExecutionContext = system.dispatcher
-  implicit val mat: Materializer = ActorMaterializer()
+  implicit val mat: Materializer = Materializer.matFromSystem(system)
   val readJournalConfig = new ReadJournalConfig(config)
 
   private val writePluginId = config.getString("write-plugin")
@@ -238,7 +238,7 @@ class JdbcReadJournal(config: Config, configPath: String)(implicit val system: E
   }
 
   def currentEventsByTag(tag: String, offset: Long): Source[EventEnvelope, NotUsed] =
-    Source.fromFuture(readJournalDao.maxJournalSequence())
+    Source.future(readJournalDao.maxJournalSequence())
       .flatMapConcat { maxOrderingInDb =>
         eventsByTag(tag, offset, terminateAfterOffset = Some(maxOrderingInDb))
       }

--- a/src/main/scala/akka/persistence/jdbc/snapshot/JdbcSnapshotStore.scala
+++ b/src/main/scala/akka/persistence/jdbc/snapshot/JdbcSnapshotStore.scala
@@ -23,7 +23,7 @@ import akka.persistence.jdbc.util.{ SlickDatabase, SlickExtension }
 import akka.persistence.snapshot.SnapshotStore
 import akka.persistence.{ SelectedSnapshot, SnapshotMetadata, SnapshotSelectionCriteria }
 import akka.serialization.{ Serialization, SerializationExtension }
-import akka.stream.{ ActorMaterializer, Materializer }
+import akka.stream.Materializer
 import com.typesafe.config.Config
 import slick.jdbc.JdbcProfile
 import slick.jdbc.JdbcBackend._
@@ -44,7 +44,7 @@ class JdbcSnapshotStore(config: Config) extends SnapshotStore {
 
   implicit val ec: ExecutionContext = context.dispatcher
   implicit val system: ActorSystem = context.system
-  implicit val mat: Materializer = ActorMaterializer()
+  implicit val mat: Materializer = Materializer.matFromSystem(system)
   val snapshotConfig = new SnapshotConfig(config)
 
   val slickDb: SlickDatabase = SlickExtension(system).database(config)

--- a/src/test/scala/akka/persistence/jdbc/SharedActorSystemTestSpec.scala
+++ b/src/test/scala/akka/persistence/jdbc/SharedActorSystemTestSpec.scala
@@ -21,7 +21,7 @@ import akka.persistence.jdbc.config.{ JournalConfig, ReadJournalConfig }
 import akka.persistence.jdbc.query.javadsl.JdbcReadJournal
 import akka.persistence.jdbc.util.{ DropCreate, SlickExtension }
 import akka.serialization.SerializationExtension
-import akka.stream.{ ActorMaterializer, Materializer }
+import akka.stream.Materializer
 import akka.util.Timeout
 import com.typesafe.config.{ Config, ConfigFactory, ConfigValue }
 import org.scalatest.BeforeAndAfterAll
@@ -37,7 +37,7 @@ abstract class SharedActorSystemTestSpec(val config: Config) extends SimpleSpec 
     })
 
   implicit lazy val system: ActorSystem = ActorSystem("test", config)
-  implicit lazy val mat: Materializer = ActorMaterializer()
+  implicit lazy val mat: Materializer = Materializer.matFromSystem(system)
 
   implicit lazy val ec: ExecutionContext = system.dispatcher
   implicit val pc: PatienceConfig = PatienceConfig(timeout = 1.minute)

--- a/src/test/scala/akka/persistence/jdbc/query/MultipleReadJournalTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/MultipleReadJournalTest.scala
@@ -19,13 +19,13 @@ package akka.persistence.jdbc.query
 import akka.persistence.jdbc.query.EventsByTagTest._
 import akka.persistence.jdbc.query.scaladsl.JdbcReadJournal
 import akka.persistence.query.{ NoOffset, PersistenceQuery }
-import akka.stream.{ ActorMaterializer, Materializer }
+import akka.stream.Materializer
 import akka.stream.scaladsl.Sink
 
 class MultipleReadJournalTest extends QueryTestSpec("h2-two-read-journals-application.conf", configOverrides) with H2Cleaner {
 
   it should "be able to create two read journals and use eventsByTag on them" in withActorSystem { implicit system =>
-    implicit val mat: Materializer = ActorMaterializer()
+    implicit val mat: Materializer = Materializer.matFromSystem(system)
     val normalReadJournal = PersistenceQuery(system).readJournalFor[JdbcReadJournal](JdbcReadJournal.Identifier)
     val secondReadJournal = PersistenceQuery(system).readJournalFor[JdbcReadJournal]("jdbc-read-journal-number-two")
 

--- a/src/test/scala/akka/persistence/jdbc/query/QueryTestSpec.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/QueryTestSpec.scala
@@ -29,7 +29,7 @@ import akka.stream.scaladsl.Sink
 import akka.stream.testkit.TestSubscriber
 import akka.stream.testkit.javadsl.{ TestSink => JavaSink }
 import akka.stream.testkit.scaladsl.TestSink
-import akka.stream.{ ActorMaterializer, Materializer }
+import akka.stream.Materializer
 import com.typesafe.config.ConfigValue
 import slick.jdbc.PostgresProfile.api._
 
@@ -48,7 +48,7 @@ trait ReadJournalOperations {
 
 class ScalaJdbcReadJournalOperations(readJournal: JdbcReadJournal)(implicit system: ActorSystem, mat: Materializer) extends ReadJournalOperations {
   def this(system: ActorSystem) =
-    this(PersistenceQuery(system).readJournalFor[JdbcReadJournal](JdbcReadJournal.Identifier))(system, ActorMaterializer()(system))
+    this(PersistenceQuery(system).readJournalFor[JdbcReadJournal](JdbcReadJournal.Identifier))(system, Materializer.matFromSystem(system))
 
   import system.dispatcher
 
@@ -92,7 +92,7 @@ class ScalaJdbcReadJournalOperations(readJournal: JdbcReadJournal)(implicit syst
 
 class JavaDslJdbcReadJournalOperations(readJournal: javadsl.JdbcReadJournal)(implicit system: ActorSystem, mat: Materializer) extends ReadJournalOperations {
   def this(system: ActorSystem) =
-    this(PersistenceQuery.get(system).getReadJournalFor(classOf[javadsl.JdbcReadJournal], JavaJdbcReadJournal.Identifier))(system, ActorMaterializer()(system))
+    this(PersistenceQuery.get(system).getReadJournalFor(classOf[javadsl.JdbcReadJournal], JavaJdbcReadJournal.Identifier))(system, Materializer.matFromSystem(system))
 
   import system.dispatcher
 

--- a/src/test/scala/akka/persistence/jdbc/query/dao/TestProbeReadJournalDao.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/dao/TestProbeReadJournalDao.scala
@@ -46,7 +46,7 @@ class TestProbeReadJournalDao(val probe: TestProbe) extends ReadJournalDao {
    */
   override def journalSequence(offset: Long, limit: Long): Source[Long, NotUsed] = {
     val f = probe.ref.ask(JournalSequence(offset, limit)).mapTo[scala.collection.immutable.Seq[Long]]
-    Source.fromFuture(f).mapConcat(identity)
+    Source.future(f).mapConcat(identity)
   }
 
   /**


### PR DESCRIPTION
In Akka 2.6, we should use the internal materializer instead of creating on each time.  

We need to update the code and remove any internal usage of `Materializer`.

The changes on the materializer are also motivated by this 'bug': 
https://github.com/akka/akka/issues/28037