### PR TITLE
events by persistenceid improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ scala:
   - 2.12.8
   - 2.13.0
 jdk:
-  - oraclejdk8
+  - openjdk8
   - openjdk11
 before_script:
   - psql -c 'create database docker;' -U postgres

--- a/project/ProjectAutoPlugin.scala
+++ b/project/ProjectAutoPlugin.scala
@@ -106,8 +106,8 @@ object ProjectAutoPlugin extends AutoPlugin {
  )
 
   def determineMimaPreviousArtifacts(scalaBinVersion: String): Set[ModuleID] = {
-    val compatVersions: Set[String] = if (scalaBinVersion.startsWith("2.13")) Set.empty else {
-      Set("3.5.0")
+    val compatVersions: Set[String] = if (scalaBinVersion.startsWith("2.13")) Set("3.5.2") else {
+      Set("3.5.0", "3.5.1", "3.5.2")
     }
     compatVersions.map { v =>
       "com.github.dnvriend" % ("akka-persistence-jdbc_" + scalaBinVersion) % v

--- a/src/main/scala/akka/persistence/jdbc/query/scaladsl/JdbcReadJournal.scala
+++ b/src/main/scala/akka/persistence/jdbc/query/scaladsl/JdbcReadJournal.scala
@@ -123,36 +123,53 @@ class JdbcReadJournal(config: Config, configPath: String)(implicit val system: E
     adapter.fromJournal(repr.payload, repr.manifest).events.map(repr.withPayload)
   }
 
-  private def currentJournalEventsByPersistenceId(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long): Source[PersistentRepr, NotUsed] =
-    readJournalDao.messages(persistenceId, fromSequenceNr, toSequenceNr, Long.MaxValue)
+  private def currentJournalEventsByPersistenceId(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long): Source[PersistentRepr, NotUsed] =
+    readJournalDao.messages(persistenceId, fromSequenceNr, toSequenceNr, max)
       .mapAsync(1)(deserializedRepr => Future.fromTry(deserializedRepr))
 
   override def currentEventsByPersistenceId(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long): Source[EventEnvelope, NotUsed] =
-    currentJournalEventsByPersistenceId(persistenceId, fromSequenceNr, toSequenceNr)
+    currentJournalEventsByPersistenceId(persistenceId, fromSequenceNr, toSequenceNr, Long.MaxValue)
       .mapConcat(adaptEvents)
       .map(repr => EventEnvelope(Sequence(repr.sequenceNr), repr.persistenceId, repr.sequenceNr, repr.payload))
 
-  override def eventsByPersistenceId(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long): Source[EventEnvelope, NotUsed] =
-    Source.unfoldAsync[Long, Seq[EventEnvelope]](Math.max(1, fromSequenceNr)) { (from: Long) =>
-      def nextFromSeqNr(xs: Seq[EventEnvelope]): Long = {
-        if (xs.isEmpty) from else xs.map(_.sequenceNr).max + 1
-      }
-      from match {
-        case x if x > toSequenceNr => Future.successful(None)
-        case _ =>
-          delaySource
-            .flatMapConcat { _ =>
-              currentJournalEventsByPersistenceId(persistenceId, from, toSequenceNr)
-                .take(readJournalConfig.maxBufferSize)
+  override def eventsByPersistenceId(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long): Source[EventEnvelope, NotUsed] = {
+    import JdbcReadJournal._
+    val batchSize = readJournalConfig.maxBufferSize
+
+    Source.unfoldAsync[(Long, FlowControl), Seq[PersistentRepr]]((Math.max(1, fromSequenceNr), Continue)) {
+      case (from, control) =>
+        def retrieveNextBatch(): Future[Option[((Long, FlowControl), Seq[PersistentRepr])]] = {
+          for {
+            xs <- currentJournalEventsByPersistenceId(persistenceId, from, toSequenceNr, batchSize).runWith(Sink.seq)
+          } yield {
+            val hasMoreEvents = xs.size == batchSize
+            // Events are ordered by sequence number, therefore the last one is the largest
+            val hasLastEvent = xs.lastOption.exists(last => last.sequenceNr >= toSequenceNr)
+            val nextControl: FlowControl =
+              if (hasLastEvent || from > toSequenceNr) Stop
+              else if (hasMoreEvents) Continue
+              else ContinueDelayed
+
+            val nextFrom: Long = if (xs.isEmpty) from
+            else {
+              // Continue querying from the last sequence number (the events are ordered)
+              xs.last.sequenceNr + 1
             }
-            .mapConcat(adaptEvents)
-            .map(repr => EventEnvelope(Sequence(repr.sequenceNr), repr.persistenceId, repr.sequenceNr, repr.payload))
-            .runWith(Sink.seq).map { xs =>
-              val newFromSeqNr = nextFromSeqNr(xs)
-              Some((newFromSeqNr, xs))
-            }
-      }
-    }.mapConcat(identity)
+            Some((nextFrom, nextControl), xs)
+          }
+        }
+
+        control match {
+          case Stop     => Future.successful(None)
+          case Continue => retrieveNextBatch()
+          case ContinueDelayed =>
+            akka.pattern.after(readJournalConfig.refreshInterval, system.scheduler)(retrieveNextBatch())
+        }
+    }
+    .mapConcat(identity)
+    .mapConcat(adaptEvents)
+    .map(repr => EventEnvelope(Sequence(repr.sequenceNr), repr.persistenceId, repr.sequenceNr, repr.payload))
+  }
 
   /**
    * Same type of query as [[EventsByTagQuery#eventsByTag]] but the event stream
@@ -202,7 +219,7 @@ class JdbcReadJournal(config: Config, configPath: String)(implicit val system: E
           } yield {
 
             val hasMoreEvents = xs.size == batchSize
-            val control =
+            val nextControl: FlowControl =
               terminateAfterOffset match {
                 // we may stop if target is behind queryUntil and we don't have more events to fetch
                 case Some(target) if !hasMoreEvents && target <= queryUntil.maxOrdering => Stop
@@ -223,7 +240,7 @@ class JdbcReadJournal(config: Config, configPath: String)(implicit val system: E
               // Continue querying from the largest offset
               xs.map(_.offset.value).max
             }
-            Some((nextStartingOffset, control), xs)
+            Some((nextStartingOffset, nextControl), xs)
           }
         }
 


### PR DESCRIPTION
This improved solution closes #241

Only the configured batch size of events are fetched each time. This implementation is based on the implementation of the eventsByTag query