### PR TITLE
fix: quote identifiers in DurableState raw SQL paths

### DIFF
--- a/core/src/main/scala/akka/persistence/jdbc/state/DurableStateQueries.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/state/DurableStateQueries.scala
@@ -23,8 +23,21 @@ import akka.persistence.jdbc.config.DurableStateTableConfiguration
     extends DurableStateTables {
   import profile.api._
 
-  lazy val tableAndSchema = durableStateTableCfg.schemaName.fold(durableStateTableCfg.tableName)(schema =>
-    s"$schema.${durableStateTableCfg.tableName}")
+  // Identifiers must be quoted via the profile so the raw-SQL INSERT/UPDATE paths use the
+  // same quoting as Slick's typed-query SELECT path. Without this, e.g. H2 in default mode
+  // uppercases unquoted identifiers, which doesn't match the lowercase quoted identifiers
+  // used by the schema and Slick's typed queries.
+  lazy val tableAndSchema = durableStateTableCfg.schemaName.fold(profile.quoteIdentifier(durableStateTableCfg.tableName))(
+    schema => s"${profile.quoteIdentifier(schema)}.${profile.quoteIdentifier(durableStateTableCfg.tableName)}")
+
+  private lazy val persistenceIdColumn = profile.quoteIdentifier(durableStateTableCfg.columnNames.persistenceId)
+  private lazy val globalOffsetColumn = profile.quoteIdentifier(durableStateTableCfg.columnNames.globalOffset)
+  private lazy val revisionColumn = profile.quoteIdentifier(durableStateTableCfg.columnNames.revision)
+  private lazy val statePayloadColumn = profile.quoteIdentifier(durableStateTableCfg.columnNames.statePayload)
+  private lazy val stateSerIdColumn = profile.quoteIdentifier(durableStateTableCfg.columnNames.stateSerId)
+  private lazy val stateSerManifestColumn = profile.quoteIdentifier(durableStateTableCfg.columnNames.stateSerManifest)
+  private lazy val tagColumn = profile.quoteIdentifier(durableStateTableCfg.columnNames.tag)
+  private lazy val stateTimestampColumn = profile.quoteIdentifier(durableStateTableCfg.columnNames.stateTimestamp)
 
   private def slickProfileToSchemaType(profile: JdbcProfile): String =
     profile match {
@@ -52,14 +65,14 @@ import akka.persistence.jdbc.config.DurableStateTableConfiguration
   private[jdbc] def insertDbWithDurableState(row: DurableStateTables.DurableStateRow, seqNextValue: String) = {
     sqlu"""INSERT INTO #$tableAndSchema
             (
-             #${durableStateTableCfg.columnNames.persistenceId},
-             #${durableStateTableCfg.columnNames.globalOffset},
-             #${durableStateTableCfg.columnNames.revision},
-             #${durableStateTableCfg.columnNames.statePayload},
-             #${durableStateTableCfg.columnNames.stateSerId},
-             #${durableStateTableCfg.columnNames.stateSerManifest},
-             #${durableStateTableCfg.columnNames.tag},
-             #${durableStateTableCfg.columnNames.stateTimestamp}
+             #$persistenceIdColumn,
+             #$globalOffsetColumn,
+             #$revisionColumn,
+             #$statePayloadColumn,
+             #$stateSerIdColumn,
+             #$stateSerManifestColumn,
+             #$tagColumn,
+             #$stateTimestampColumn
             )
             VALUES
             (
@@ -77,15 +90,15 @@ import akka.persistence.jdbc.config.DurableStateTableConfiguration
 
   private[jdbc] def updateDbWithDurableState(row: DurableStateTables.DurableStateRow, seqNextValue: String) = {
     sqlu"""UPDATE #$tableAndSchema
-           SET #${durableStateTableCfg.columnNames.globalOffset} = #${seqNextValue},
-               #${durableStateTableCfg.columnNames.revision} = ${row.revision},
-               #${durableStateTableCfg.columnNames.statePayload} = ${row.statePayload},
-               #${durableStateTableCfg.columnNames.stateSerId} = ${row.stateSerId},
-               #${durableStateTableCfg.columnNames.stateSerManifest} = ${row.stateSerManifest},
-               #${durableStateTableCfg.columnNames.tag} = ${row.tag},
-               #${durableStateTableCfg.columnNames.stateTimestamp} = ${System.currentTimeMillis}
-           WHERE #${durableStateTableCfg.columnNames.persistenceId} = ${row.persistenceId}
-             AND #${durableStateTableCfg.columnNames.revision} = ${row.revision} - 1
+           SET #$globalOffsetColumn = #${seqNextValue},
+               #$revisionColumn = ${row.revision},
+               #$statePayloadColumn = ${row.statePayload},
+               #$stateSerIdColumn = ${row.stateSerId},
+               #$stateSerManifestColumn = ${row.stateSerManifest},
+               #$tagColumn = ${row.tag},
+               #$stateTimestampColumn = ${System.currentTimeMillis}
+           WHERE #$persistenceIdColumn = ${row.persistenceId}
+             AND #$revisionColumn = ${row.revision} - 1
         """
   }
 

--- a/core/src/main/scala/akka/persistence/jdbc/state/DurableStateQueries.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/state/DurableStateQueries.scala
@@ -27,18 +27,18 @@ import akka.persistence.jdbc.config.DurableStateTableConfiguration
   // same quoting as Slick's typed-query SELECT path. Without this, e.g. H2 in default mode
   // uppercases unquoted identifiers, which doesn't match the lowercase quoted identifiers
   // used by the schema and Slick's typed queries.
-  lazy val tableAndSchema =
+  val tableAndSchema =
     durableStateTableCfg.schemaName.fold(profile.quoteIdentifier(durableStateTableCfg.tableName))(schema =>
       s"${profile.quoteIdentifier(schema)}.${profile.quoteIdentifier(durableStateTableCfg.tableName)}")
 
-  private lazy val persistenceIdColumn = profile.quoteIdentifier(durableStateTableCfg.columnNames.persistenceId)
-  private lazy val globalOffsetColumn = profile.quoteIdentifier(durableStateTableCfg.columnNames.globalOffset)
-  private lazy val revisionColumn = profile.quoteIdentifier(durableStateTableCfg.columnNames.revision)
-  private lazy val statePayloadColumn = profile.quoteIdentifier(durableStateTableCfg.columnNames.statePayload)
-  private lazy val stateSerIdColumn = profile.quoteIdentifier(durableStateTableCfg.columnNames.stateSerId)
-  private lazy val stateSerManifestColumn = profile.quoteIdentifier(durableStateTableCfg.columnNames.stateSerManifest)
-  private lazy val tagColumn = profile.quoteIdentifier(durableStateTableCfg.columnNames.tag)
-  private lazy val stateTimestampColumn = profile.quoteIdentifier(durableStateTableCfg.columnNames.stateTimestamp)
+  private val persistenceIdColumn = profile.quoteIdentifier(durableStateTableCfg.columnNames.persistenceId)
+  private val globalOffsetColumn = profile.quoteIdentifier(durableStateTableCfg.columnNames.globalOffset)
+  private val revisionColumn = profile.quoteIdentifier(durableStateTableCfg.columnNames.revision)
+  private val statePayloadColumn = profile.quoteIdentifier(durableStateTableCfg.columnNames.statePayload)
+  private val stateSerIdColumn = profile.quoteIdentifier(durableStateTableCfg.columnNames.stateSerId)
+  private val stateSerManifestColumn = profile.quoteIdentifier(durableStateTableCfg.columnNames.stateSerManifest)
+  private val tagColumn = profile.quoteIdentifier(durableStateTableCfg.columnNames.tag)
+  private val stateTimestampColumn = profile.quoteIdentifier(durableStateTableCfg.columnNames.stateTimestamp)
 
   private def slickProfileToSchemaType(profile: JdbcProfile): String =
     profile match {

--- a/core/src/main/scala/akka/persistence/jdbc/state/DurableStateQueries.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/state/DurableStateQueries.scala
@@ -27,8 +27,9 @@ import akka.persistence.jdbc.config.DurableStateTableConfiguration
   // same quoting as Slick's typed-query SELECT path. Without this, e.g. H2 in default mode
   // uppercases unquoted identifiers, which doesn't match the lowercase quoted identifiers
   // used by the schema and Slick's typed queries.
-  lazy val tableAndSchema = durableStateTableCfg.schemaName.fold(profile.quoteIdentifier(durableStateTableCfg.tableName))(
-    schema => s"${profile.quoteIdentifier(schema)}.${profile.quoteIdentifier(durableStateTableCfg.tableName)}")
+  lazy val tableAndSchema =
+    durableStateTableCfg.schemaName.fold(profile.quoteIdentifier(durableStateTableCfg.tableName))(schema =>
+      s"${profile.quoteIdentifier(schema)}.${profile.quoteIdentifier(durableStateTableCfg.tableName)}")
 
   private lazy val persistenceIdColumn = profile.quoteIdentifier(durableStateTableCfg.columnNames.persistenceId)
   private lazy val globalOffsetColumn = profile.quoteIdentifier(durableStateTableCfg.columnNames.globalOffset)

--- a/core/src/test/resources/h2-default-mode-application.conf
+++ b/core/src/test/resources/h2-default-mode-application.conf
@@ -1,0 +1,50 @@
+# Copyright (C) 2019 - 2025 Lightbend Inc. <https://akka.io>
+
+// general.conf is included only for shared settings used for the akka-persistence-jdbc tests
+include "general.conf"
+
+# Same as h2-application.conf but without DATABASE_TO_UPPER=false. This exercises H2 in its
+# default mode, where unquoted identifiers are uppercased — the failure mode for the durable
+# state identifier-quoting regression.
+
+akka {
+  persistence {
+    journal {
+      plugin = "jdbc-journal"
+    }
+    snapshot-store {
+      plugin = "jdbc-snapshot-store"
+    }
+  }
+}
+
+jdbc-journal {
+  slick = ${slick}
+}
+
+jdbc-snapshot-store {
+  slick = ${slick}
+}
+
+jdbc-read-journal {
+  slick = ${slick}
+}
+
+jdbc-durable-state-store {
+  slick = ${slick}
+}
+
+another-jdbc-durable-state-store = ${jdbc-durable-state-store}
+
+slick {
+  profile = "slick.jdbc.H2Profile$"
+  db {
+    url = "jdbc:h2:mem:test-database"
+    user = "root"
+    password = "root"
+    driver = "org.h2.Driver"
+    numThreads = 5
+    maxConnections = 5
+    minConnections = 1
+  }
+}

--- a/core/src/test/resources/h2-default-mode-application.conf
+++ b/core/src/test/resources/h2-default-mode-application.conf
@@ -4,8 +4,8 @@
 include "general.conf"
 
 # Same as h2-application.conf but without DATABASE_TO_UPPER=false. This exercises H2 in its
-# default mode, where unquoted identifiers are uppercased — the failure mode for the durable
-# state identifier-quoting regression.
+# default mode, where unquoted identifiers are uppercased — the failure mode that the durable
+# state identifier-quoting fix addresses.
 
 akka {
   persistence {

--- a/core/src/test/scala/akka/persistence/jdbc/state/scaladsl/JdbcDurableStateSpec.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/state/scaladsl/JdbcDurableStateSpec.scala
@@ -423,8 +423,8 @@ class H2DurableStateSpec extends JdbcDurableStateSpec(ConfigFactory.load("h2-app
     ActorSystem("test", config.withFallback(customSerializers))
 }
 
-// Regression coverage for #969: in H2's default mode unquoted identifiers are uppercased,
-// so raw-SQL paths in DurableStateQueries must quote identifiers via the profile.
+// In H2's default mode unquoted identifiers are uppercased, so raw-SQL paths in
+// DurableStateQueries must quote identifiers via the profile to match the schema.
 class H2DefaultModeDurableStateSpec
     extends JdbcDurableStateSpec(ConfigFactory.load("h2-default-mode-application.conf"), H2) {
   implicit lazy val system: ActorSystem =

--- a/core/src/test/scala/akka/persistence/jdbc/state/scaladsl/JdbcDurableStateSpec.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/state/scaladsl/JdbcDurableStateSpec.scala
@@ -422,3 +422,11 @@ class H2DurableStateSpec extends JdbcDurableStateSpec(ConfigFactory.load("h2-app
   implicit lazy val system: ActorSystem =
     ActorSystem("test", config.withFallback(customSerializers))
 }
+
+// Regression coverage for #969: in H2's default mode unquoted identifiers are uppercased,
+// so raw-SQL paths in DurableStateQueries must quote identifiers via the profile.
+class H2DefaultModeDurableStateSpec
+    extends JdbcDurableStateSpec(ConfigFactory.load("h2-default-mode-application.conf"), H2) {
+  implicit lazy val system: ActorSystem =
+    ActorSystem("test", config.withFallback(customSerializers))
+}


### PR DESCRIPTION
## Summary

`DurableStateQueries` builds INSERT/UPDATE statements with Slick's `#$` raw interpolation, which injects the table and column names **unquoted**, while the SELECT path (typed queries) quotes them via the profile. On H2 in its default mode unquoted identifiers are uppercased, so writes against the lowercase quoted schema (`schema/h2/h2-create-schema.sql`) fail:

```
Table "DURABLE_STATE" not found (candidates are: "durable_state")
```

The journal/snapshot plugins are unaffected — they use Slick's typed query API exclusively.

The existing H2 test configs hid this by passing `DATABASE_TO_UPPER=false` on the JDBC URL, which disables H2's default uppercasing.

## Fix

Quote `tableAndSchema` and every injected column name through `profile.quoteIdentifier(...)` in [`DurableStateQueries.scala`](core/src/main/scala/akka/persistence/jdbc/state/DurableStateQueries.scala). The profile produces `"…"` for H2/Postgres/Oracle/SqlServer and backticks for MySQL — matching the quoting Slick already applies on the typed-query path and the schema DDL.

## Regression coverage

Adds `H2DefaultModeDurableStateSpec` running against a new `h2-default-mode-application.conf` that omits `DATABASE_TO_UPPER=false`. Without this fix the new spec reproduces the bug (14 failures with the `Table "DURABLE_STATE" not found` error); with the fix all 18 tests pass.

The shared `h2-application.conf` is intentionally left as-is — `H2ScalaEventsByTagMigrationTest` constructs unquoted DDL on purpose for the migration scenario and relies on the workaround.

## Test plan

- [x] `core/testOnly akka.persistence.jdbc.state.scaladsl.H2DurableStateSpec` (existing, passes)
- [x] `core/testOnly akka.persistence.jdbc.state.scaladsl.H2DefaultModeDurableStateSpec` (new regression spec, passes — and fails as expected when fix is reverted)
- [x] `core/testOnly akka.persistence.jdbc.query.H2ScalaEventsByTagMigrationTest` (existing, still passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)